### PR TITLE
improve the checkpoint functionality and add summarize feature

### DIFF
--- a/c++/triqs_modest/checkpoint.hpp
+++ b/c++/triqs_modest/checkpoint.hpp
@@ -21,33 +21,69 @@ namespace triqs::modest {
   using block_mat_t       = std::vector<nda::matrix<dcomplex>>;
 
   /**
-   * @brief Minimal iteration data required to restart a DMFT loop.
+   * @brief Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+   *
+   * The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+   * from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+   * (`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+   * empty vectors so callers only fill what they have.
    */
   struct iteration_data {
     double mu;
+
+    // restart-required outputs
     std::vector<block_gf_imfreq_t> Sigma_imp_list;
     std::vector<block_mat_t> Sigma_hartree_list;
+
+    // additional outputs (optional)
+    std::vector<block_gf_imfreq_t> Gimp_list = {};
+    std::vector<block_mat_t> Sigma_dc_list   = {}; // CSC double-counting self-energy
+
+    // inputs (optional)
+    std::vector<block_gf_imfreq_t> Gloc_list  = {};
+    std::vector<block_gf_imfreq_t> Delta_list = {};
+
+    static std::string hdf5_format() { return "IterationData"; }
 
     C2PY_IGNORE friend void mpi_broadcast(iteration_data &x, mpi::communicator c = {}, int root = 0) {
       mpi::broadcast(x.mu, c, root);
       mpi::broadcast(x.Sigma_imp_list, c, root);
       mpi::broadcast(x.Sigma_hartree_list, c, root);
+      mpi::broadcast(x.Gimp_list, c, root);
+      mpi::broadcast(x.Sigma_dc_list, c, root);
+      mpi::broadcast(x.Gloc_list, c, root);
+      mpi::broadcast(x.Delta_list, c, root);
     }
   };
 
-  // HDF5 serialization for iteration_data
+  // HDF5 serialization for iteration_data. Layout:
+  //   <name>/mu
+  //   <name>/inputs/{Gloc_list, Delta_list}
+  //   <name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list, Sigma_dc_list}
   inline void h5_write(h5::group g, std::string const &name, iteration_data const &data) {
     auto g2 = g.create_group(name);
     h5::write(g2, "mu", data.mu);
-    h5::write(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::write(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.create_group("inputs");
+    h5::write(g_in, "Gloc_list", data.Gloc_list);
+    h5::write(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.create_group("outputs");
+    h5::write(g_out, "Gimp_list", data.Gimp_list);
+    h5::write(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::write(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::write(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   inline void h5_read(h5::group g, std::string const &name, iteration_data &data) {
     auto g2 = g.open_group(name);
     h5::read(g2, "mu", data.mu);
-    h5::read(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::read(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.open_group("inputs");
+    h5::read(g_in, "Gloc_list", data.Gloc_list);
+    h5::read(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.open_group("outputs");
+    h5::read(g_out, "Gimp_list", data.Gimp_list);
+    h5::read(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::read(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::read(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   // ===========================================================================
@@ -73,8 +109,7 @@ namespace triqs::modest {
     /// Open existing or create new checkpoint directory.
     checkpoint(std::string dirname) : _dirname{dirname}, _iter_file{dirname + "/iterations.h5"} {
       if (fs::exists(dirname)) {
-        if (!fs::is_directory(dirname))
-          throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
+        if (!fs::is_directory(dirname)) throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
         auto file = h5::file(_iter_file, 'r');
         _n_iter   = long(h5::group{file}.get_all_subgroup_dataset_names().size());
       } else {

--- a/doc/reference/python/checkpointing.rst
+++ b/doc/reference/python/checkpointing.rst
@@ -3,10 +3,55 @@
 Checkpointing
 *************
 
-HDF5-based checkpointing for DMFT calculations: iteration containers and
-the checkpoint manager base class.
+HDF5-based checkpointing for DMFT calculations. ModEST exposes two
+classes:
+
+* :py:class:`~triqs_modest.utils.file_io.CheckpointBase` — the
+  ``c2py``-wrapped C++ checkpoint manager. Use it directly for pure
+  C++ workflows or single-rank Python scripts.
+* :py:class:`~triqs_modest.utils.checkpoint.Checkpointer` — a
+  Python wrapper around ``CheckpointBase`` that is safe to call on all
+  MPI ranks, supports a create-or-open constructor with optional initial
+  data, accepts arbitrary keyword extras via :py:class:`h5.HDFArchive`,
+  and exposes the convergence-log helper ``summarize()``.
 
 .. autosummary::
 
    triqs_modest.utils.file_io.IterationData
    triqs_modest.utils.file_io.CheckpointBase
+   triqs_modest.utils.checkpoint.Checkpointer
+
+Iteration data
+==============
+
+Each iteration stored in the checkpoint is an
+:py:class:`~triqs_modest.utils.file_io.IterationData` carrying the
+restart-required fields and several optional diagnostic / CSC fields:
+
+* **Restart payload** (always populated):
+  ``mu``, ``Sigma_imp_list``, ``Sigma_hartree_list``, ``Sigma_dc_list``.
+  ``Sigma_dc_list`` is ``[]`` for non-CSC runs and populated for CSC.
+* **Solver outputs** (optional):
+  ``Gimp_list`` — impurity Green's functions returned by the solver.
+* **Solver inputs** (optional):
+  ``Gloc_list`` — local Green's function fed to the solver;
+  ``Delta_list`` — hybridization function fed to the solver.
+
+Optional fields default to empty lists. Simple DMFT runs can ignore
+them; CSC and machine-learning workflows fill them in.
+
+The on-disk HDF5 layout reflects this split: each iteration is written
+under ``<name>/inputs/{Gloc_list, Delta_list}`` and
+``<name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list,
+Sigma_dc_list}``.
+
+Diagnostics
+===========
+
+:py:meth:`~triqs_modest.utils.checkpoint.Checkpointer.summarize` prints
+a per-iteration convergence log to ``stdout`` (or a user-supplied
+stream). Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+skipped if no iteration has the corresponding list populated, and
+``--`` placeholders appear for iterations whose individual lists are
+empty. The call is a no-op on non-master ranks.

--- a/python/triqs_modest/utils/checkpoint.py
+++ b/python/triqs_modest/utils/checkpoint.py
@@ -7,9 +7,12 @@ Wraps CheckpointBase (the c2py-exposed C++ class) and adds:
 - Keyword-extras written alongside required iteration data (master only)
 - restart() broadcasts last iteration to all ranks (collective)
 - Full Python iteration, indexing, and len() support
+- summarize() prints a convergence log of mu and orbital-resolved occupations
 """
 
 import os
+import sys
+import numpy as np
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 from .file_io import CheckpointBase, IterationData
@@ -20,9 +23,13 @@ __all__ = ["Checkpointer", "IterationData"]
 class Checkpointer:
     """MPI-aware checkpoint manager for DMFT calculations.
 
-    Enforces saving the minimal restart set (mu, Sigma_imp_list, Sigma_hartree_list)
-    per iteration and optionally stores additional quantities (Green's functions,
-    density matrices, etc.) in the same HDF5 group via keyword arguments.
+    Stores per iteration the restart-required self-energies (``mu``,
+    ``Sigma_imp_list``, ``Sigma_hartree_list``) along with optional inputs
+    (``Gloc_list``, ``Delta_list``) and outputs (``Gimp_list``,
+    ``Sigma_dc_list``) of the impurity solve. The optional fields default
+    to empty lists — simple DMFT runs can ignore them; CSC and ML workflows
+    fill them in. Anything else can still be passed through ``**extras``
+    and written to the same HDF5 group via ``HDFArchive``.
 
     All methods are safe to call on all MPI ranks — no ``is_master_node()`` guards
     required in user code. Only the master process performs HDF5 file I/O.
@@ -41,23 +48,28 @@ class Checkpointer:
 
     .. code-block:: python
 
-        chkpt    = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding" : E})
-        last     = chkpt.restart()          # collective — data on all ranks
+        chkpt = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding": E})
+        last  = chkpt.restart()              # collective — data on all ranks
         if last is not None:
             Sigma_dyn    = last.Sigma_imp_list[0]
             Sigma_static = last.Sigma_hartree_list[0]
+            Sigma_dc     = last.Sigma_dc_list[0] if last.Sigma_dc_list else None
         else:
             Sigma_dyn, Sigma_static = make_zero_self_energies(mesh)
+            Sigma_dc = None
 
         it_shift = len(chkpt)
 
         for n in range(it_shift, n_loops):
             ...
-            chkpt.append(
-                IterationData(mu=mu, Sigma_imp_list=[Sigma_dyn],
-                              Sigma_hartree_list=[Sigma_static]),
-                Delta_iw=Delta, Gimp_iw=Gimp, dm=dm,
-            )
+            chkpt.append(IterationData(
+                mu=mu,
+                Sigma_imp_list=[Sigma_dyn], Sigma_hartree_list=[Sigma_static],
+                Gimp_list=[Gimp], Sigma_dc_list=[Sigma_dc] if Sigma_dc is not None else [],
+                Gloc_list=[Gloc], Delta_list=[Delta],
+            ))
+
+        chkpt.summarize()                    # print a convergence log
     """
 
     def __init__(self, dirname, initial_data=None) -> None:
@@ -97,8 +109,14 @@ class Checkpointer:
         """Return last iteration data on all MPI ranks, or None if empty.
 
         Collective operation — all ranks must call this together. Master reads
-        from disk; components (mu, Sigma_imp_list, Sigma_hartree_list) are
-        broadcast individually to all ranks.
+        from disk; the returned ``IterationData`` is broadcast to all ranks.
+
+        Carries the restart-relevant fields: ``mu``, ``Sigma_imp_list``,
+        ``Sigma_hartree_list``, and ``Sigma_dc_list``. The DC list is ``[]``
+        for non-CSC runs and populated for CSC; callers can detect with
+        ``if it.Sigma_dc_list:``. Diagnostic fields (``Gimp_list``,
+        ``Gloc_list``, ``Delta_list``) are not in the restart payload — read
+        them via ``chkpt[i]`` on master or via ``summarize()``.
 
         Returns
         -------
@@ -112,12 +130,82 @@ class Checkpointer:
 
         iter_data = None
         if mpi.is_master_node():
-            mu             = self._cpp[-1].mu                
-            Sigma_imp_list = self._cpp[-1].Sigma_imp_list    
-            Sigma_H_list   = self._cpp[-1].Sigma_hartree_list
-            iter_data = IterationData(mu=mu, Sigma_imp_list=Sigma_imp_list, Sigma_hartree_list=Sigma_H_list)
+            last = self._cpp[-1]
+            iter_data = IterationData(
+                mu=last.mu,
+                Sigma_imp_list=last.Sigma_imp_list,
+                Sigma_hartree_list=last.Sigma_hartree_list,
+                Sigma_dc_list=last.Sigma_dc_list,
+            )
         iter_data = mpi.bcast(iter_data)
         return iter_data
+
+
+    def summarize(self, file=None) -> None:
+        """Print a per-iteration convergence log (master only).
+
+        Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+        occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+        skipped if no iteration in the checkpoint has the corresponding list
+        populated. Iterations whose individual lists are empty show ``--``
+        placeholders.
+
+        Parameters
+        ----------
+        file : file-like, optional
+            Destination stream; defaults to ``sys.stdout``.
+        """
+        if not mpi.is_master_node(): return
+        if file is None: file = sys.stdout
+
+        n_iter = len(self._cpp)
+        if n_iter == 0:
+            print("Checkpointer: no iterations stored.", file=file)
+            return
+
+        iters = [self._cpp[n] for n in range(n_iter)]
+
+        def orbital_layout(blocklist):
+            """Return [(imp_idx, block_name, orb_idx), ...] from the first non-empty list, or []."""
+            for it in iters:
+                lst = blocklist(it)
+                if lst:
+                    layout = []
+                    for i, bgf in enumerate(lst):
+                        for bn, g in bgf:
+                            for a in range(g.target_shape[0]):
+                                layout.append((i, bn, a))
+                    return layout
+            return []
+
+        imp_layout = orbital_layout(lambda it: it.Gimp_list)
+        loc_layout = orbital_layout(lambda it: it.Gloc_list)
+
+        headers = ["iter", "mu"]
+        headers += [f"n_imp{i}_{bn}_{a}_imp" for (i, bn, a) in imp_layout]
+        headers += [f"n_imp{i}_{bn}_{a}_loc" for (i, bn, a) in loc_layout]
+        widths = [max(len(h), 12) for h in headers]
+
+        def fmt_row(cells):
+            return "  ".join(f"{c:>{w}}" for c, w in zip(cells, widths))
+
+        print(fmt_row(headers), file=file)
+        print("  ".join("-" * w for w in widths), file=file)
+
+        def diag_occupations(blocklist, layout):
+            if not blocklist:
+                return ["--"] * len(layout)
+            diags = {}
+            for i, bgf in enumerate(blocklist):
+                for bn, g in bgf:
+                    diags[(i, bn)] = np.diag(g.density()).real
+            return [f"{diags[(i, bn)][a]:.6f}" for (i, bn, a) in layout]
+
+        for n, it in enumerate(iters):
+            row = [str(n), f"{it.mu:.6f}"]
+            row += diag_occupations(it.Gimp_list, imp_layout)
+            row += diag_occupations(it.Gloc_list, loc_layout)
+            print(fmt_row(row), file=file)
 
 
     @property

--- a/python/triqs_modest/utils/file_io.wrap.cxx
+++ b/python/triqs_modest/utils/file_io.wrap.cxx
@@ -15,6 +15,7 @@
 #define C2PY_VERSION_MINOR 1
 
 #include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
 
 using c2py::operator""_a;
 
@@ -44,14 +45,18 @@ static int synth_constructor_0(PyObject *self, PyObject *args, PyObject *kwargs)
   de("mu", self_c.mu, false);
   de("Sigma_imp_list", self_c.Sigma_imp_list, false);
   de("Sigma_hartree_list", self_c.Sigma_hartree_list, false);
+  de("Gimp_list", self_c.Gimp_list, true);
+  de("Sigma_dc_list", self_c.Sigma_dc_list, true);
+  de("Gloc_list", self_c.Gloc_list, true);
+  de("Delta_list", self_c.Delta_list, true);
   return de.check();
 }
 
 template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = synth_constructor_0;
 
 template <>
-const std::string c2py::tp_ctor_doc<_c2py_cls_0> =
-   c2py::replace_tags(R"DOC(Synthesized constructor with the following keyword arguments:
+const std::string c2py::tp_ctor_doc<_c2py_cls_0> = c2py::replace_tags(
+   R"DOC(Synthesized constructor with the following keyword arguments:
 
 Parameters
 ----------
@@ -61,27 +66,47 @@ Sigma_imp_list : {par_1}
 
 Sigma_hartree_list : {par_2}
 
+Gimp_list : {par_3}, default={}
+
+Sigma_dc_list : {par_4}, default={}
+
+Gloc_list : {par_5}, default={}
+
+Delta_list : {par_6}, default={}
+
 )DOC",
-                      "par",
-                      {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
-                       c2py::python_typename<std::vector<triqs::modest::block_mat_t>>()});
+   "par",
+   {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>()});
 
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
 constexpr auto _c2py_doc_member_0 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_1 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_2 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_3 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_4 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_5 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_6 = R"DOC()DOC";
 static PyObject *prop_get_dict_0(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
   c2py::pydict dic;
   dic["mu"]                 = self_c.mu;
   dic["Sigma_imp_list"]     = self_c.Sigma_imp_list;
   dic["Sigma_hartree_list"] = self_c.Sigma_hartree_list;
+  dic["Gimp_list"]          = self_c.Gimp_list;
+  dic["Sigma_dc_list"]      = self_c.Sigma_dc_list;
+  dic["Gloc_list"]          = self_c.Gloc_list;
+  dic["Delta_list"]         = self_c.Delta_list;
   return dic.new_ref();
 }
 
@@ -92,12 +117,21 @@ constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {
    c2py::getsetdef_from_member<&_c2py_cls_0::mu, _c2py_cls_0>("mu", _c2py_doc_member_0),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_imp_list, _c2py_cls_0>("Sigma_imp_list", _c2py_doc_member_1),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_hartree_list, _c2py_cls_0>("Sigma_hartree_list", _c2py_doc_member_2),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gimp_list, _c2py_cls_0>("Gimp_list", _c2py_doc_member_3),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_dc_list, _c2py_cls_0>("Sigma_dc_list", _c2py_doc_member_4),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gloc_list, _c2py_cls_0>("Gloc_list", _c2py_doc_member_5),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Delta_list, _c2py_cls_0>("Delta_list", _c2py_doc_member_6),
    {"__dict__", (getter)prop_get_dict_0, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
 template <>
-const std::string c2py::tp_doc<_c2py_cls_0> =
-   R"DOC(Minimal iteration data required to restart a DMFT loop.)DOC" + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
+const std::string c2py::tp_doc<_c2py_cls_0> = R"DOC(Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+
+The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+(`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+empty vectors so callers only fill what they have.)DOC"
+   + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
 // --------- class _c2py_cls_1 -----------
 using _c2py_cls_1                                            = triqs::modest::checkpoint<triqs::modest::iteration_data>;
 template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
@@ -197,6 +231,12 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_file_io() {
   _add_type(_c2py_cls_0, "IterationData");
   _add_type(_c2py_cls_1, "CheckpointBase");
 #undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
 
   return m;
 }


### PR DESCRIPTION
## Summary

The checkpoint feature in modest was envisioned to provide high-level abstractions so that the user can quickly save their DMFT data with minimal additions lines of code in their Python scripts. The goal of this PR is to complete the checkpointing feature providing a fully-fledged checkpointing class. Now the user does not have to write any hdf5 boilerplate in their python scripts and their data is automatically saved in an organized archive. Using the checkpoint class now standardizes the output formats, which will be useful for future features like mixers, etc. 

Previously, the `iteration_data` struct carried only the minimal restart set (`mu`, `Sigma_imp_list`, `Sigma_hartree_list`). However, CSC calculations and post-processing tasks often require more, e.g., DC self-energy to restart the CSC loop or the solver's inputs/outputs to what the loop actually did. This PR adds those fields.  Additionally, we provide a convenient `.summarize()' method to quickly create convergence logs of the DMFT loop.

## Changes

**`iteration_data` gains four optional fields** (`c++/triqs_modest/checkpoint.hpp`):

| field | role |
|---|---|
| `Sigma_dc_list` | CSC double-counting self-energy — restart-required for CSC |
| `Gimp_list` | impurity Green's function (solver output) |
| `Gloc_list` | local lattice Green's function (solver input) |
| `Delta_list` | hybridization (solver input) |

All default to `{}`, so existing call sites are unaffected. `mpi_broadcast` covers
all of them.

**HDF5 layout now mirrors the input/output split** 

```
<name>/mu
<name>/inputs/{Gloc_list, Delta_list}
<name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list, Sigma_dc_list}
```

**`Checkpointer.summarize(file=None)`** (`python/triqs_modest/utils/checkpoint.py`)
prints one row per stored iteration — `iter`, `mu`, and the orbital-resolved
diagonal occupations from `Gimp_list` and `Gloc_list`. Column groups are omitted
when no iteration has the corresponding list populated; individual empty
iterations render `--`. Master-rank only.

**`restart()`** now also carries `Sigma_dc_list` in the broadcast payload, so a CSC
run can resume its DC. 

## Compatibility

 **This changes the on-disk layout of `iteration_data`, with no fallback.**
4.0.0 and 4.0.1 wrote `Sigma_imp_list` / `Sigma_hartree_list` flat under
`<name>/`; `h5_read` now opens `<name>/inputs` and `<name>/outputs` and will throw
on those archives. Previously generated `*.ckpt/iterations.h5` files will not be 
backwards compatible.
