### PR TITLE
OBE printing, post-process h5 I/O, and the partial-projector rename

### DIFF
--- a/c++/triqs_modest/checkpoint.hpp
+++ b/c++/triqs_modest/checkpoint.hpp
@@ -21,33 +21,69 @@ namespace triqs::modest {
   using block_mat_t       = std::vector<nda::matrix<dcomplex>>;
 
   /**
-   * @brief Minimal iteration data required to restart a DMFT loop.
+   * @brief Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+   *
+   * The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+   * from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+   * (`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+   * empty vectors so callers only fill what they have.
    */
   struct iteration_data {
     double mu;
+
+    // restart-required outputs
     std::vector<block_gf_imfreq_t> Sigma_imp_list;
     std::vector<block_mat_t> Sigma_hartree_list;
+
+    // additional outputs (optional)
+    std::vector<block_gf_imfreq_t> Gimp_list = {};
+    std::vector<block_mat_t> Sigma_dc_list   = {}; // CSC double-counting self-energy
+
+    // inputs (optional)
+    std::vector<block_gf_imfreq_t> Gloc_list  = {};
+    std::vector<block_gf_imfreq_t> Delta_list = {};
+
+    static std::string hdf5_format() { return "IterationData"; }
 
     C2PY_IGNORE friend void mpi_broadcast(iteration_data &x, mpi::communicator c = {}, int root = 0) {
       mpi::broadcast(x.mu, c, root);
       mpi::broadcast(x.Sigma_imp_list, c, root);
       mpi::broadcast(x.Sigma_hartree_list, c, root);
+      mpi::broadcast(x.Gimp_list, c, root);
+      mpi::broadcast(x.Sigma_dc_list, c, root);
+      mpi::broadcast(x.Gloc_list, c, root);
+      mpi::broadcast(x.Delta_list, c, root);
     }
   };
 
-  // HDF5 serialization for iteration_data
+  // HDF5 serialization for iteration_data. Layout:
+  //   <name>/mu
+  //   <name>/inputs/{Gloc_list, Delta_list}
+  //   <name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list, Sigma_dc_list}
   inline void h5_write(h5::group g, std::string const &name, iteration_data const &data) {
     auto g2 = g.create_group(name);
     h5::write(g2, "mu", data.mu);
-    h5::write(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::write(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.create_group("inputs");
+    h5::write(g_in, "Gloc_list", data.Gloc_list);
+    h5::write(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.create_group("outputs");
+    h5::write(g_out, "Gimp_list", data.Gimp_list);
+    h5::write(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::write(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::write(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   inline void h5_read(h5::group g, std::string const &name, iteration_data &data) {
     auto g2 = g.open_group(name);
     h5::read(g2, "mu", data.mu);
-    h5::read(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::read(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.open_group("inputs");
+    h5::read(g_in, "Gloc_list", data.Gloc_list);
+    h5::read(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.open_group("outputs");
+    h5::read(g_out, "Gimp_list", data.Gimp_list);
+    h5::read(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::read(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::read(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   // ===========================================================================
@@ -73,8 +109,7 @@ namespace triqs::modest {
     /// Open existing or create new checkpoint directory.
     checkpoint(std::string dirname) : _dirname{dirname}, _iter_file{dirname + "/iterations.h5"} {
       if (fs::exists(dirname)) {
-        if (!fs::is_directory(dirname))
-          throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
+        if (!fs::is_directory(dirname)) throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
         auto file = h5::file(_iter_file, 'r');
         _n_iter   = long(h5::group{file}.get_all_subgroup_dataset_names().size());
       } else {

--- a/c++/triqs_modest/h5.cpp
+++ b/c++/triqs_modest/h5.cpp
@@ -6,6 +6,7 @@
 #include <h5/h5.hpp>
 #include "downfolding.hpp"
 #include "embedding.hpp"
+#include "postprocess.hpp"
 #include <H5Tpublic.h> // HDF5 type creation API
 
 template <> h5::hid_t h5::detail::hid_t_of<triqs::modest::embedding::imp_block_t>() {
@@ -124,4 +125,34 @@ namespace triqs::modest {
     h5_write(subgroup, "P", obe.P);
     //h5_write(subgroup, "ibz_symm_ops", obe.ibz_symm_ops);
   }
+
+  // spectral function containers
+  void h5_read(h5::group g, std::string const &name, spectral_function_w &Aw) {
+    auto subgroup = g.open_group(name);
+    assert_hdf5_format(g, Aw);
+    h5_read(subgroup, "total", Aw.total);
+    h5_read(subgroup, "projected", Aw.projected);
+  }
+
+  void h5_write(h5::group g, std::string const &name, spectral_function_w const &Aw) {
+    auto subgroup = g.create_group(name);
+    write_hdf5_format(g, Aw);
+    h5_write(subgroup, "total", Aw.total);
+    h5_write(subgroup, "projected", Aw.projected);
+  }
+
+  void h5_read(h5::group g, std::string const &name, spectral_function_kw &Akw) {
+    auto subgroup = g.open_group(name);
+    assert_hdf5_format(g, Akw);
+    h5_read(subgroup, "total", Akw.total);
+    h5_read(subgroup, "projected", Akw.projected);
+  }
+
+  void h5_write(h5::group g, std::string const &name, spectral_function_kw const &Akw) {
+    auto subgroup = g.create_group(name);
+    write_hdf5_format(g, Akw);
+    h5_write(subgroup, "total", Akw.total);
+    h5_write(subgroup, "projected", Akw.projected);
+  }
+
 } // namespace triqs::modest

--- a/c++/triqs_modest/loaders.cpp
+++ b/c++/triqs_modest/loaders.cpp
@@ -71,9 +71,9 @@ namespace triqs::modest {
   //-------------------------------------------------------
   // Enumerate the different reading modes for the obe factory functions.
   enum class ReadMode {
-    Correlated,      // reads bands, projectors, and correlated shells from "dft_input"
-    ThetaProjectors, // read bands ands shells from "dft_input" and projectors from "dft_parproj_input" ("proj_mat_all")
-    Bands            // read bands and projectors from "dft_bands_input"
+    Correlated,        // reads bands, projectors, and correlated shells from "dft_input"
+    PartialProjectors, // read bands ands shells from "dft_input" and projectors from "dft_parproj_input" ("proj_mat_all")
+    Bands              // read bands and projectors from "dft_bands_input"
   };
 
   //-------------------------------------------------------
@@ -101,9 +101,9 @@ namespace triqs::modest {
              })
          | tl::to<std::vector<cmat_t>>();
     };
-    return (mode == ReadMode::Correlated)  ? read_mats(root["dft_input"], "rot_mat", "rot_mat_time_inv") :
-       (mode == ReadMode::ThetaProjectors) ? read_mats(root["dft_parproj_input"], "rot_mat_all", "rot_mat_all_time_inv") :
-                                             throw std::runtime_error("This should not happen!");
+    return (mode == ReadMode::Correlated)    ? read_mats(root["dft_input"], "rot_mat", "rot_mat_time_inv") :
+       (mode == ReadMode::PartialProjectors) ? read_mats(root["dft_parproj_input"], "rot_mat_all", "rot_mat_all_time_inv") :
+                                               throw std::runtime_error("This should not happen!");
   }
 
   //-------------------------------------------------------
@@ -115,9 +115,9 @@ namespace triqs::modest {
       if (m == ReadMode::Correlated || m == ReadMode::Bands) {
         return (m == ReadMode::Correlated) ? as<nda::array<dcomplex, 5>>(root["dft_input"]["proj_mat"]) :
                                              as<nda::array<dcomplex, 5>>(root["dft_bands_input"]["proj_mat"]);
-      } else if (m == ReadMode::ThetaProjectors) {
+      } else if (m == ReadMode::PartialProjectors) {
         auto tmp = as<nda::array<dcomplex, 6>>(root["dft_parproj_input"]["proj_mat_all"]);
-        // FIXME: The θ projectors have an extra dimesion called ir. Not sure why it is there...
+        // FIXME: The partial projectors have an extra dimesion called ir. Not sure why it is there...
         return nda::array<dcomplex, 5>{tmp(r_all, r_all, r_all, 0, r_all, r_all)};
       } else {
         throw std::runtime_error{"This should not happen!"};
@@ -151,7 +151,7 @@ namespace triqs::modest {
   // Read band dispersion and k-weights according to ReadMode. (internal)
   std::tuple<nda::array<dcomplex, 4>, nda::matrix<long>, nda::array<double, 1>> read_bands_and_weights(std::string filename, ReadMode mode) {
     auto root = h5::proxy{filename, 'r'};
-    if (mode == ReadMode::Correlated || mode == ReadMode::ThetaProjectors) {
+    if (mode == ReadMode::Correlated || mode == ReadMode::PartialProjectors) {
       auto g_dft = root["dft_input"];
       return {as<nda::array<dcomplex, 4>>(g_dft["hopping"]), as<nda::matrix<long>>(g_dft["n_orbitals"]),
               as<nda::array<double, 1>>(g_dft["bz_weights"])};
@@ -355,7 +355,7 @@ namespace triqs::modest {
     return {target_density, std::move(obe_final)};
   }
 
-  one_body_elements_on_grid read_theta_projectors_for_obe(const std::string &filename, const one_body_elements_on_grid &obe) {
+  one_body_elements_on_grid read_partial_projectors_for_obe(const std::string &filename, const one_body_elements_on_grid &obe) {
     //check for group and throw error
     auto h5root = h5::proxy{filename, 'r'};
     if (!h5root.has_group("dft_parproj_input")) {
@@ -363,7 +363,7 @@ namespace triqs::modest {
     }
 
     // all the atomic shells
-    auto atomic_shells = read_atomic_shells(filename, ReadMode::ThetaProjectors);
+    auto atomic_shells = read_atomic_shells(filename, ReadMode::PartialProjectors);
 
     // The decomposition and rotations must be embedded from the C spcae to the W space
     auto new_block_decomposition = detail::inject_to_new_space(obe.C_space.atoms_block_decomposition(), obe.C_space.atomic_shells(), atomic_shells);
@@ -371,29 +371,29 @@ namespace triqs::modest {
     // The local space expanded from C to W
     auto W_space = local_space{obe.C_space.spin_kind(), atomic_shells, new_block_decomposition, {}, {}};
 
-    // rotation matrices using ThetaProjector mode
-    auto rot_mats = read_rotation_matrices(filename, ReadMode::ThetaProjectors);
+    // rotation matrices using PartialProjectors mode
+    auto rot_mats = read_rotation_matrices(filename, ReadMode::PartialProjectors);
 
     // read and rotate projectors
-    auto atom_decomp = W_space.atomic_decomposition() | tl::to<std::vector<long>>();
-    auto P_k         = load_rotate_and_format_projectors(filename, ReadMode::ThetaProjectors, rot_mats, atom_decomp);
-    auto theta_proj  = downfolding_projector{.spin_kind = obe.C_space.spin_kind(), .P_k = std::move(P_k), .n_bands_per_k = obe.H.n_bands_per_k};
+    auto atom_decomp  = W_space.atomic_decomposition() | tl::to<std::vector<long>>();
+    auto P_k          = load_rotate_and_format_projectors(filename, ReadMode::PartialProjectors, rot_mats, atom_decomp);
+    auto partial_proj = downfolding_projector{.spin_kind = obe.C_space.spin_kind(), .P_k = std::move(P_k), .n_bands_per_k = obe.H.n_bands_per_k};
 
     // create a new IBZ symmetrizer that spans all atoms instead of just the correlated atoms
-    auto symm_ops = (obe.ibz_symm_ops) ? std::optional<ibz_symmetry_ops>(read_ibz_symmetry_ops(filename, ReadMode::ThetaProjectors)) :
+    auto symm_ops = (obe.ibz_symm_ops) ? std::optional<ibz_symmetry_ops>(read_ibz_symmetry_ops(filename, ReadMode::PartialProjectors)) :
                                          std::optional<ibz_symmetry_ops>{};
-    return one_body_elements_on_grid{.H = obe.H, .C_space = W_space, .P = theta_proj, .ibz_symm_ops = symm_ops};
+    return one_body_elements_on_grid{.H = obe.H, .C_space = W_space, .P = partial_proj, .ibz_symm_ops = symm_ops};
   }
 
   //-------------------------------------------------------
-  // Prepare one-body elements with the Θ projectors.
-  one_body_elements_on_grid one_body_elements_with_theta_projectors(std::string const &filename, one_body_elements_on_grid const &obe) {
+  // Prepare one-body elements with the partial projectors.
+  one_body_elements_on_grid one_body_elements_with_partial_projectors(std::string const &filename, one_body_elements_on_grid const &obe) {
 
     mpi::communicator comm = {};
     int root               = 0;
     one_body_elements_on_grid obe_final;
 
-    if (comm.rank() == root) { obe_final = read_theta_projectors_for_obe(filename, obe); }
+    if (comm.rank() == root) { obe_final = read_partial_projectors_for_obe(filename, obe); }
 
     mpi::broadcast(obe_final, comm, root);
     return obe_final;

--- a/c++/triqs_modest/loaders.hpp
+++ b/c++/triqs_modest/loaders.hpp
@@ -17,7 +17,7 @@ namespace triqs::modest {
   C2PY_IGNORE std::pair<double, one_body_elements_on_grid> read_obe_from_dft_converter_hdf5(std::string const &filename, double threshold = 1.e-5,
                                                                                             bool diagonalize_hloc = false);
 
-  C2PY_IGNORE one_body_elements_on_grid read_theta_projectors_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
+  C2PY_IGNORE one_body_elements_on_grid read_partial_projectors_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
 
   C2PY_IGNORE one_body_elements_on_grid read_data_on_high_symm_path_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
 
@@ -68,7 +68,7 @@ namespace triqs::modest {
 
   /**
    * @ingroup one_body_elements
-   * @brief Create a one-body elements with the \f$ \Theta \f$ projectors.
+   * @brief Create a one-body elements with partial (all-atom) projectors.
    *
    * @details Using the data from the "dft_parproj_input" group, the local space, downfolding projectors,
    * and optional IBZ symmetry ops are prepared to create a one-body elements. This object is
@@ -76,9 +76,9 @@ namespace triqs::modest {
    *
    * @param filename Hdf5 file from DFTtools converter with "dft_parproj_input" group.
    * @param obe One-body elements that was used in the DMFT calculation.
-   * @return One-body elements using the \f$ \Theta \f$ projectors.
+   * @return One-body elements using the partial projectors.
    */
-  one_body_elements_on_grid one_body_elements_with_theta_projectors(std::string const &filename, one_body_elements_on_grid const &obe);
+  one_body_elements_on_grid one_body_elements_with_partial_projectors(std::string const &filename, one_body_elements_on_grid const &obe);
 
   /**
    * @ingroup one_body_elements

--- a/c++/triqs_modest/obe_tb.cpp
+++ b/c++/triqs_modest/obe_tb.cpp
@@ -59,7 +59,7 @@ namespace triqs::modest {
      : H{std::move(H_sigma)} {
 
     // check that appropriate Hamiltonian information was provided
-    if (H[0].n_orbitals() != H[1].n_orbitals()) {
+    if (spin_kind != spin_kind_e::NonColinear && H[0].n_orbitals() != H[1].n_orbitals()) {
       throw std::runtime_error(
          "Cannot construct a one_body_elements "
          "using up and down H_k that have a different number of orbitals.");
@@ -153,7 +153,7 @@ namespace triqs::modest {
       }
     }
 
-    return one_body_elements_tb(std::move(new_H), obe.C_space);
+    return {std::move(new_H), obe.C_space};
   }
 
   // -----------------------------------------------------------------------
@@ -179,16 +179,17 @@ namespace triqs::modest {
       return ext_mat;
     };
 
-    std::vector<nda::array<dcomplex, 2>> new_hoppings;
-    for (auto const &tR : obe.H[0].hoppings()) new_hoppings.emplace_back(extend_matrix(tR));
-    auto new_tb_H = std::vector<tb_hk>{{Rs, std::move(new_hoppings)}};
+    std::vector<nda::array<dcomplex, 2>> ext_hoppings;
+    for (auto const &tR : obe.H[0].hoppings()) ext_hoppings.emplace_back(extend_matrix(tR));
+    std::vector<tb_hk> ext_tb_H;
+    ext_tb_H.emplace_back(Rs, std::move(ext_hoppings));
 
     auto const &sh         = obe.C_space.atomic_shells();
     auto new_atomic_shells = sh
        | stdv::transform([](auto const &s) { return atomic_orbs{.dim = 2 * s.dim, .l = s.l, .cls_idx = s.cls_idx, .dft_idx = s.dft_idx}; })
        | tl::to<std::vector>();
 
-    return one_body_elements_tb(std::move(new_tb_H), spin_kind_e::NonColinear, std::move(new_atomic_shells));
+    return {std::move(ext_tb_H), spin_kind_e::NonColinear, std::move(new_atomic_shells)};
   }
 
   // -----------------------------------------------------------------------

--- a/c++/triqs_modest/postprocess.cpp
+++ b/c++/triqs_modest/postprocess.cpp
@@ -33,30 +33,30 @@ namespace triqs::modest {
 
   } // namespace detail
 
-  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe_theta, downfolding_projector const &Proj, double mu,
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
     using nda::linalg::inv;
 
     auto const &mesh = Sigma_w(0, 0).mesh();
-    auto n_sigma     = obe_theta.C_space.n_sigma();
-    auto n_k         = obe_theta.H.n_k();
-    auto n_M         = obe_theta.C_space.dim();
+    auto n_sigma     = obe.C_space.n_sigma();
+    auto n_k         = obe.H.n_k();
+    auto n_M         = obe.C_space.dim();
     auto n_w         = mesh.size();
     auto im          = dcomplex(0, 1.0);
     auto delta       = im * broadening;
 
     // Accumulate local Green's function over k-points
-    auto gloc_result = make_block2_gf(mesh, obe_theta.C_space.Gc_block_shape());
+    auto gloc_result = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
 
     for (auto k_idx : range(n_k)) {
       for (auto sigma : range(n_sigma)) {
-        auto P    = obe_theta.P.P(sigma, k_idx);
+        auto P    = obe.P.P(sigma, k_idx);
         auto Pdag = dagger(P);
-        auto H_k  = obe_theta.H.H(sigma, k_idx);
-        auto w_k  = obe_theta.H.k_weights(k_idx);
+        auto H_k  = obe.H.H(sigma, k_idx);
+        auto w_k  = obe.H.k_weights(k_idx);
 
         // Precompute upfolded self-energy for all frequencies
-        auto PSP_all = detail::upfold_self_energy_all_freq(obe_theta, Proj, Sigma_w, k_idx, sigma);
+        auto PSP_all = detail::upfold_self_energy_all_freq(obe, Proj, Sigma_w, k_idx, sigma);
 
         for (auto &&[n, w] : enumerate(mesh)) {
           auto G_k = nda::matrix<dcomplex>{inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all))};
@@ -65,22 +65,22 @@ namespace triqs::modest {
       }
     }
 
-    if (auto const &S = obe_theta.ibz_symm_ops; S) { gloc_result = S->symmetrize(gloc_result, obe_theta.C_space.atomic_decomposition()); }
+    if (auto const &S = obe.ibz_symm_ops; S) { gloc_result = S->symmetrize(gloc_result, obe.C_space.atomic_decomposition()); }
 
     // Extract spectral functions from local Green's function
     auto total     = nda::zeros<double>(n_sigma, n_w);
-    auto per_theta = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
+    auto projected = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
 
     for (auto sigma : range(n_sigma)) {
       auto const &G = gloc_result(0, sigma).data();
       for (auto &&[n, w] : enumerate(mesh)) {
         auto g                            = nda::matrix<dcomplex>{G(n, r_all, r_all)};
         total(sigma, n)                   = (-1.0 / M_PI) * imag(trace(g));
-        per_theta(sigma, n, r_all, r_all) = real(im * (g - dagger(g)) / (2 * M_PI));
+        projected(sigma, n, r_all, r_all) = real(im * (g - dagger(g)) / (2 * M_PI));
       }
     }
 
-    return {.total = total, .per_theta = per_theta};
+    return {.total = total, .projected = projected};
   }
 
   nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
@@ -125,10 +125,10 @@ namespace triqs::modest {
     auto n_M         = obe.C_space.dim();
     auto delta       = dcomplex(0, broadening);
 
-    auto data      = nda::zeros<double>(n_sigma, n_k, n_w);
-    auto proj_data = nda::zeros<double>(n_sigma, n_k, n_w, n_M, n_M);
+    auto total     = nda::zeros<double>(n_sigma, n_k, n_w);
+    auto projected = nda::zeros<double>(n_sigma, n_k, n_w, n_M);
 
-#pragma omp parallel for default(none) shared(n_k, n_sigma, n_w, obe, mu, delta, Sigma_w, broadening, mesh, data, proj_data, r_all)
+#pragma omp parallel for default(none) shared(n_k, n_sigma, n_M, obe, mu, delta, Sigma_w, mesh, total, projected, r_all)
     for (auto k_idx : range(n_k)) {
       for (auto sigma : range(n_sigma)) {
         auto P    = obe.P.P(sigma, k_idx);
@@ -142,16 +142,16 @@ namespace triqs::modest {
           auto G_k = inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all));
 
           // Total spectral function from trace
-          data(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
+          total(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
 
-          // Orbital-resolved from projection
-          auto PGP                                 = P * nda::matrix<dcomplex>{G_k} * Pdag;
-          proj_data(sigma, k_idx, n, r_all, r_all) = (-1.0 / M_PI) * imag(PGP);
+          // Orbital-resolved from projection, diagonal in m
+          auto PGP = nda::matrix<dcomplex>{P * nda::matrix<dcomplex>{G_k} * Pdag};
+          for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = (-1.0 / M_PI) * imag(PGP(m, m));
         }
       }
     }
 
-    return {.data = data, .proj_data = proj_data};
+    return {.total = total, .projected = projected};
   }
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/postprocess.hpp
+++ b/c++/triqs_modest/postprocess.hpp
@@ -37,9 +37,25 @@ namespace triqs::modest {
 
   /// Store data of spectral functions.
   struct spectral_function_kw {
-    nda::array<double, 3> data;      ///< \f$ A^\sigma(k,\omega) \f$.
-    nda::array<double, 5> proj_data; ///< \f$ A^\sigma(k,\omega) \f$.
+    nda::array<double, 3> total;     ///< \f$ A^\sigma(k,\omega) \f$.
+    nda::array<double, 4> projected; ///< \f$ A^\sigma_{mm}(k,\omega) \f$ (diagonal in \f$m\f$).
+    static std::string hdf5_format() { return "SpectralFunctionKw"; }
+    friend std::ostream &operator<<(std::ostream &out, spectral_function_kw const &x);
   };
+
+  /// Store data of spectral functions.
+  struct spectral_function_w {
+    nda::array<double, 2> total;     ///< \f$ A^\sigma(\omega) \f$.
+    nda::array<double, 4> projected; ///< \f$ A^{\sigma}_{mm'}(\omega) \f$.
+    static std::string hdf5_format() { return "SpectralFunctionW"; }
+    friend std::ostream &operator<<(std::ostream &out, spectral_function_w const &x);
+  };
+
+  /// h5 read and writes
+  void h5_read(h5::group g, std::string const &name, spectral_function_kw &x);
+  void h5_write(h5::group g, std::string const &name, spectral_function_kw const &x);
+  void h5_read(h5::group g, std::string const &name, spectral_function_w &x);
+  void h5_write(h5::group g, std::string const &name, spectral_function_w const &x);
 
   /**
    * @ingroup post
@@ -54,24 +70,18 @@ namespace triqs::modest {
   spectral_function_kw spectral_function_on_high_symmetry_path(one_body_elements_on_grid const &obe, double mu,
                                                                block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
 
-  /// Store data of spectral functions.
-  struct spectral_function_w {
-    nda::array<double, 2> total;     ///< \f$ A^\sigma(\omega) \f$.
-    nda::array<double, 4> per_theta; ///< \f$ A^{\sigma}_{mm'}(\omega) \f$.
-  };
-
   /**
    * @ingroup post
    * @brief Compute the atom- and orbital-resolved spectral function (interacting density of states).
    *
-   * @param obe_theta One-body elements on grid created from one_body_elements_with_theta_projectors.
+   * @param obe One-body elements on grid created from one_body_elements_with_partial_projectors.
    * @param Proj Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
    * @param mu Chemical potential.
    * @param Sigma_w Self-energy in real-frequencies.
    * @param broadening Spectral broadening.
    * @return Atom- and orbital-resolved spectral function.
    */
-  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe_theta, downfolding_projector const &Proj, double mu,
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
 
   /**
@@ -90,7 +100,7 @@ namespace triqs::modest {
    * @param broadening Spectral broadening.
    * @return Band-resolved spectral function matrix.
    */
-  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu,
-                                          block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
+  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
+                                          double broadening = 0.01);
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/printing.cpp
+++ b/c++/triqs_modest/printing.cpp
@@ -5,6 +5,7 @@
 
 #include "./downfolding.hpp"
 #include "./embedding.hpp"
+#include "./postprocess.hpp"
 #include <algorithm>
 #include <fmt/base.h>
 #include <triqs/utility/report_stream.hpp>
@@ -166,6 +167,26 @@ namespace triqs::modest {
 
   std::ostream &operator<<(std::ostream &out, embedding const &E) {
     out << E.description(false);
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  std::ostream &operator<<(std::ostream &out, spectral_function_w const &x) {
+    out << "Spectral functions on a real-frequency mesh [spectral_function_w]:\n";
+    auto out1 = triqs::utility::indented_ostream(out, 2);
+    out1 << fmt::format("total[σ, ω]            A^σ(ω)         shape = {}\n", x.total.shape());
+    out1 << fmt::format("projected[σ, ω, m, m'] A^σ_mm'(ω)     shape = {}\n", x.projected.shape());
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  std::ostream &operator<<(std::ostream &out, spectral_function_kw const &x) {
+    out << "Momentum-resolved spectral functions on a real-frequency mesh [spectral_function_kw]:\n";
+    auto out1 = triqs::utility::indented_ostream(out, 2);
+    out1 << fmt::format("total[σ, k, ω]              A^σ(k, ω)       shape = {}\n", x.total.shape());
+    out1 << fmt::format("projected[σ, k, ω, m]       A^σ_mm(k, ω)    shape = {}\n", x.projected.shape());
     return out;
   }
 

--- a/c++/triqs_modest/printing.cpp
+++ b/c++/triqs_modest/printing.cpp
@@ -2,7 +2,7 @@
 // This file is part of TRIQS/modest and is licensed under the terms of GPLv3 or later.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // See LICENSE in the root of this distribution for details.
-
+#include "./obe_tb.hpp"
 #include "./downfolding.hpp"
 #include "./embedding.hpp"
 #include "./postprocess.hpp"
@@ -87,6 +87,28 @@ namespace triqs::modest {
     out2 << obe.P;
     out1 << fmt::format("IBZ = {}\n", bool(obe.ibz_symm_ops));
     if (obe.ibz_symm_ops) { out2 << obe.ibz_symm_ops.value(); };
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, one_body_elements_tb const &obe) {
+    auto out1 = triqs::utility::indented_ostream(out, 2); // same stream, but shifted by 2 spaces
+    auto out2 = triqs::utility::indented_ostream(out, 4);
+    out << "One body elements tight-binding: Fourier representation of one-body dispersion [one_body_elements_tb]\n";
+    out1 << "H^σ(k):\n";
+    for (auto &h : obe.H) { out2 << h; }
+    out1 << "C_space:\n";
+    out2 << obe.C_space;
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, one_body_elements_gw const &obe) {
+    auto out1 = triqs::utility::indented_ostream(out, 2); // same stream, but shifted by 2 spaces
+    auto out2 = triqs::utility::indented_ostream(out, 4);
+    out << "One body elements GW: [one_body_elements_gw]\n";
+    out1 << "C_space:\n";
+    out2 << obe.C_space;
+    out1 << "P:\n";
+    out2 << obe.P;
     return out;
   }
 

--- a/doc/reference/python/checkpointing.rst
+++ b/doc/reference/python/checkpointing.rst
@@ -3,10 +3,55 @@
 Checkpointing
 *************
 
-HDF5-based checkpointing for DMFT calculations: iteration containers and
-the checkpoint manager base class.
+HDF5-based checkpointing for DMFT calculations. ModEST exposes two
+classes:
+
+* :py:class:`~triqs_modest.utils.file_io.CheckpointBase` — the
+  ``c2py``-wrapped C++ checkpoint manager. Use it directly for pure
+  C++ workflows or single-rank Python scripts.
+* :py:class:`~triqs_modest.utils.checkpoint.Checkpointer` — a
+  Python wrapper around ``CheckpointBase`` that is safe to call on all
+  MPI ranks, supports a create-or-open constructor with optional initial
+  data, accepts arbitrary keyword extras via :py:class:`h5.HDFArchive`,
+  and exposes the convergence-log helper ``summarize()``.
 
 .. autosummary::
 
    triqs_modest.utils.file_io.IterationData
    triqs_modest.utils.file_io.CheckpointBase
+   triqs_modest.utils.checkpoint.Checkpointer
+
+Iteration data
+==============
+
+Each iteration stored in the checkpoint is an
+:py:class:`~triqs_modest.utils.file_io.IterationData` carrying the
+restart-required fields and several optional diagnostic / CSC fields:
+
+* **Restart payload** (always populated):
+  ``mu``, ``Sigma_imp_list``, ``Sigma_hartree_list``, ``Sigma_dc_list``.
+  ``Sigma_dc_list`` is ``[]`` for non-CSC runs and populated for CSC.
+* **Solver outputs** (optional):
+  ``Gimp_list`` — impurity Green's functions returned by the solver.
+* **Solver inputs** (optional):
+  ``Gloc_list`` — local Green's function fed to the solver;
+  ``Delta_list`` — hybridization function fed to the solver.
+
+Optional fields default to empty lists. Simple DMFT runs can ignore
+them; CSC and machine-learning workflows fill them in.
+
+The on-disk HDF5 layout reflects this split: each iteration is written
+under ``<name>/inputs/{Gloc_list, Delta_list}`` and
+``<name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list,
+Sigma_dc_list}``.
+
+Diagnostics
+===========
+
+:py:meth:`~triqs_modest.utils.checkpoint.Checkpointer.summarize` prints
+a per-iteration convergence log to ``stdout`` (or a user-supplied
+stream). Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+skipped if no iteration has the corresponding list populated, and
+``--`` placeholders appear for iterations whose individual lists are
+empty. The call is a no-op on non-master ranks.

--- a/doc/reference/python/one_body_elements.rst
+++ b/doc/reference/python/one_body_elements.rst
@@ -24,7 +24,7 @@ Factories
 
    triqs_modest.obe.one_body_elements_from_dft_converter
    triqs_modest.obe.one_body_elements_on_high_symmetry_path
-   triqs_modest.obe.one_body_elements_with_theta_projectors
+   triqs_modest.obe.one_body_elements_with_partial_projectors
    triqs_modest.obe.make_one_body_elements_gw
    triqs_modest.obe_tb.one_body_elements_from_wannier90
 
@@ -48,3 +48,15 @@ Supporting types
    triqs_modest.obe.LocalSpace
    triqs_modest.obe.AtomicOrbs
    triqs_modest.obe.IbzSymmetryOps
+
+Operations
+==========
+
+Apply a unitary rotation :math:`U` to the local correlated basis of an
+existing :py:class:`~triqs_modest.obe.OneBodyElementsOnGrid` (or its
+:py:class:`~triqs_modest.obe.IbzSymmetryOps`). The projector
+:math:`P(\mathbf{k})` is transformed as in :eq:`eq_ChangeBasisP`.
+
+.. autosummary::
+
+   triqs_modest.obe.rotate_local_basis

--- a/python/triqs_modest/obe.toml
+++ b/python/triqs_modest/obe.toml
@@ -27,7 +27,7 @@ namespaces = "triqs triqs::modest"
 #    if reject_names and reject_names match Qname : skip X
 #    else keep X.
 
-match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
+match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|rotate_local_basis|spin_kind_e)"
 
 # Only keep elements declared in files matching the pattern
 # match_files = "" # String must be a regex

--- a/python/triqs_modest/obe.toml
+++ b/python/triqs_modest/obe.toml
@@ -27,7 +27,7 @@ namespaces = "triqs triqs::modest"
 #    if reject_names and reject_names match Qname : skip X
 #    else keep X.
 
-match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_theta_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
+match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
 
 # Only keep elements declared in files matching the pattern
 # match_files = "" # String must be a regex

--- a/python/triqs_modest/obe.wrap.cxx
+++ b/python/triqs_modest/obe.wrap.cxx
@@ -117,14 +117,14 @@ template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
 template <> inline constexpr auto c2py::tp_name<_c2py_cls_1> = "triqs_modest.obe.LocalSpace";
 static const auto _c2py_init_0                               = c2py::dispatcher_c_kw_t{
    c2py::c_constructor<_c2py_cls_1, triqs::modest::spin_kind_e, std::vector<triqs::modest::atomic_orbs>,
-                       nda::basic_array<std::vector<long, std::allocator<long>>, 2, nda::C_layout, 'A',
-                                        nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                       nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
-                                                         nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                                        2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                       nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
-                                                         nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                                        1, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(
+                                                     nda::basic_array<std::vector<long, std::allocator<long>>, 2, nda::C_layout, 'A',
+                                                                      nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                     nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
+                                                                                       nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                                      2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                     nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
+                                                                                       nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                                      1, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(
       "spin_kind", "atomic_shells", "irreps_decomp_per_atom", "rotation_from_dft_to_local_basis", "rotation_from_spherical_to_dft_basis"),
    c2py::c_constructor<_c2py_cls_1>()};
 template <> constexpr initproc c2py::tp_init<_c2py_cls_1> = c2py::pyfkw_constructor<_c2py_init_0>;
@@ -948,10 +948,10 @@ static auto const _c2py_fun_8 = c2py::dispatcher_f_kw_t{c2py::cfun(
    },
    "filename", "obe")};
 
-// one_body_elements_with_theta_projectors
+// one_body_elements_with_partial_projectors
 static auto const _c2py_fun_9 = c2py::dispatcher_f_kw_t{c2py::cfun(
    [](const std::string &filename, const triqs::modest::one_body_elements_on_grid &obe) {
-     return triqs::modest::one_body_elements_with_theta_projectors(filename, obe);
+     return triqs::modest::one_body_elements_with_partial_projectors(filename, obe);
    },
    "filename", "obe")};
 
@@ -1054,7 +1054,7 @@ Returns
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
 static const auto _c2py_doc_9 =
    _c2py_fun_9.doc(R"DOC(
-Create a one-body elements with the :math:`\Theta` projectors.
+Create a one-body elements with partial (all-atom) projectors.
 
 Using the data from the "dft_parproj_input" group, the local space, downfolding projectors,
 and optional IBZ symmetry ops are prepared to create a one-body elements. This object is
@@ -1070,7 +1070,7 @@ obe : {par_1}
 Returns
 -------
 {ret_0}
-   One-body elements using the :math:`\Theta` projectors.
+   One-body elements using the partial projectors.
 )DOC",
                    {{c2py::python_typename<const std::string &>()}, {c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()}},
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
@@ -1080,7 +1080,7 @@ static PyMethodDef module_methods[] = {
    {"make_one_body_elements_gw", (PyCFunction)c2py::pyfkw<_c2py_fun_6>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_6.c_str()},
    {"one_body_elements_from_dft_converter", (PyCFunction)c2py::pyfkw<_c2py_fun_7>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_7.c_str()},
    {"one_body_elements_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_8>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_8.c_str()},
-   {"one_body_elements_with_theta_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
+   {"one_body_elements_with_partial_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/python/triqs_modest/obe.wrap.cxx
+++ b/python/triqs_modest/obe.wrap.cxx
@@ -955,6 +955,21 @@ static auto const _c2py_fun_9 = c2py::dispatcher_f_kw_t{c2py::cfun(
    },
    "filename", "obe")};
 
+// rotate_local_basis
+static auto const _c2py_fun_10 = c2py::dispatcher_f_kw_t{
+   c2py::cfun(
+      [](const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &U,
+         const triqs::modest::ibz_symmetry_ops &x) { return triqs::modest::rotate_local_basis(U, x); },
+      "U", "x"),
+   c2py::cfun(
+      [](const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &U,
+         const triqs::modest::one_body_elements_on_grid &x) { return triqs::modest::rotate_local_basis(U, x); },
+      "U", "x")};
+
 static const auto _c2py_doc_6 =
    _c2py_fun_6.doc(R"DOC(
 Create a one-body elements for GW calculations with CoQui.
@@ -1074,6 +1089,33 @@ Returns
 )DOC",
                    {{c2py::python_typename<const std::string &>()}, {c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()}},
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
+static const auto _c2py_doc_10 = _c2py_fun_10.doc(
+   R"DOC(
+[1] Change basis
+
+------
+
+[2] Rotates the local basis of the downfolding projector
+
+------
+
+Parameters
+----------
+U : {par_0}
+   Rotations by block in atomic decomposition
+x : {par_1}
+   ibz_symmetry_ops to rotate
+
+Returns
+-------
+{ret_0}
+   A new symmetrizer operating in the rotated basis U^† U
+)DOC",
+   {{c2py::python_typename<const nda::basic_array<
+       nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+       nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &>()},
+    {c2py::python_typename<const triqs::modest::ibz_symmetry_ops &>()}},
+   {c2py::python_typename<triqs::modest::ibz_symmetry_ops>()});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {
@@ -1081,6 +1123,7 @@ static PyMethodDef module_methods[] = {
    {"one_body_elements_from_dft_converter", (PyCFunction)c2py::pyfkw<_c2py_fun_7>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_7.c_str()},
    {"one_body_elements_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_8>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_8.c_str()},
    {"one_body_elements_with_partial_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
+   {"rotate_local_basis", (PyCFunction)c2py::pyfkw<_c2py_fun_10>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_10.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/python/triqs_modest/obe_tb.wrap.cxx
+++ b/python/triqs_modest/obe_tb.wrap.cxx
@@ -29,7 +29,7 @@ template <> inline constexpr auto c2py::tp_name<_c2py_cls_0> = "triqs_modest.obe
 static const auto _c2py_init_0                               = c2py::dispatcher_c_kw_t{
    c2py::c_constructor<_c2py_cls_0, std::vector<triqs::experimental::lattice::tb_hk>, triqs::modest::local_space>("H_sigma", "ls"),
    c2py::c_constructor<_c2py_cls_0, std::vector<triqs::experimental::lattice::tb_hk>, triqs::modest::spin_kind_e,
-                       std::vector<triqs::modest::atomic_orbs>>("H_sigma", "spin_kind", "atomic_shells")};
+                                                     std::vector<triqs::modest::atomic_orbs>>("H_sigma", "spin_kind", "atomic_shells")};
 template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = c2py::pyfkw_constructor<_c2py_init_0>;
 template <>
 const std::string c2py::tp_ctor_doc<_c2py_cls_0> = _c2py_init_0.doc(R"DOC(

--- a/python/triqs_modest/post_processing.wrap.cxx
+++ b/python/triqs_modest/post_processing.wrap.cxx
@@ -15,6 +15,7 @@
 #define C2PY_VERSION_MINOR 1
 
 #include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
 
 using c2py::operator""_a;
 
@@ -41,8 +42,8 @@ static int synth_constructor_0(PyObject *self, PyObject *args, PyObject *kwargs)
     return -1;
   }
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
-  de("data", self_c.data, false);
-  de("proj_data", self_c.proj_data, false);
+  de("total", self_c.total, false);
+  de("projected", self_c.projected, false);
   return de.check();
 }
 
@@ -54,29 +55,31 @@ const std::string c2py::tp_ctor_doc<_c2py_cls_0> = c2py::replace_tags(
 
 Parameters
 ----------
-data : {par_0}
+total : {par_0}
 
-proj_data : {par_1}
+projected : {par_1}
 
 )DOC",
    "par",
    {c2py::python_typename<nda::basic_array<double, 3, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(),
-    c2py::python_typename<nda::basic_array<double, 5, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
+    c2py::python_typename<nda::basic_array<double, 4, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
 
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
 constexpr auto _c2py_doc_member_0 = R"DOC(:math:`A^\sigma(k,\omega)`.)DOC";
-constexpr auto _c2py_doc_member_1 = R"DOC(:math:`A^\sigma(k,\omega)`.)DOC";
+constexpr auto _c2py_doc_member_1 = R"DOC(:math:`A^\sigma_{mm}(k,\omega)` (diagonal in :math:`m`).)DOC";
 static PyObject *prop_get_dict_0(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
   c2py::pydict dic;
-  dic["data"]      = self_c.data;
-  dic["proj_data"] = self_c.proj_data;
+  dic["total"]     = self_c.total;
+  dic["projected"] = self_c.projected;
   return dic.new_ref();
 }
 
@@ -84,8 +87,8 @@ static PyObject *prop_get_dict_0(PyObject *self, void *) {
 
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {
-   c2py::getsetdef_from_member<&_c2py_cls_0::data, _c2py_cls_0>("data", _c2py_doc_member_0),
-   c2py::getsetdef_from_member<&_c2py_cls_0::proj_data, _c2py_cls_0>("proj_data", _c2py_doc_member_1),
+   c2py::getsetdef_from_member<&_c2py_cls_0::total, _c2py_cls_0>("total", _c2py_doc_member_0),
+   c2py::getsetdef_from_member<&_c2py_cls_0::projected, _c2py_cls_0>("projected", _c2py_doc_member_1),
    {"__dict__", (getter)prop_get_dict_0, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -112,7 +115,7 @@ static int synth_constructor_1(PyObject *self, PyObject *args, PyObject *kwargs)
   }
   auto &self_c = *(((c2py::wrap<_c2py_cls_1> *)self)->_c);
   de("total", self_c.total, false);
-  de("per_theta", self_c.per_theta, false);
+  de("projected", self_c.projected, false);
   return de.check();
 }
 
@@ -126,7 +129,7 @@ Parameters
 ----------
 total : {par_0}
 
-per_theta : {par_1}
+projected : {par_1}
 
 )DOC",
    "par",
@@ -136,7 +139,9 @@ per_theta : {par_1}
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_1>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_1>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_1>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_1>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
@@ -146,7 +151,7 @@ static PyObject *prop_get_dict_1(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_1> *)self)->_c);
   c2py::pydict dic;
   dic["total"]     = self_c.total;
-  dic["per_theta"] = self_c.per_theta;
+  dic["projected"] = self_c.projected;
   return dic.new_ref();
 }
 
@@ -155,7 +160,7 @@ static PyObject *prop_get_dict_1(PyObject *self, void *) {
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_1>[] = {
    c2py::getsetdef_from_member<&_c2py_cls_1::total, _c2py_cls_1>("total", _c2py_doc_member_2),
-   c2py::getsetdef_from_member<&_c2py_cls_1::per_theta, _c2py_cls_1>("per_theta", _c2py_doc_member_3),
+   c2py::getsetdef_from_member<&_c2py_cls_1::projected, _c2py_cls_1>("projected", _c2py_doc_member_3),
    {"__dict__", (getter)prop_get_dict_1, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -167,10 +172,10 @@ const std::string c2py::tp_doc<_c2py_cls_1> =
 
 // projected_spectral_function
 static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
-   c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe_theta, const triqs::modest::downfolding_projector &Proj, double mu,
+   c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, const triqs::modest::downfolding_projector &Proj, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
-                 double broadening) { return triqs::modest::projected_spectral_function(obe_theta, Proj, mu, Sigma_w, broadening); },
-              "obe_theta", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
+                 double broadening) { return triqs::modest::projected_spectral_function(obe, Proj, mu, Sigma_w, broadening); },
+              "obe", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
 
 // spectral_function
 static auto const _c2py_fun_1 =
@@ -192,8 +197,8 @@ Compute the atom- and orbital-resolved spectral function (interacting density of
 
 Parameters
 ----------
-obe_theta : {par_0}
-   One-body elements on grid created from one_body_elements_with_theta_projectors.
+obe : {par_0}
+   One-body elements on grid created from one_body_elements_with_partial_projectors.
 Proj : {par_1}
    Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
 mu : {par_2}
@@ -332,6 +337,13 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_post_processi
   _add_type(_c2py_cls_0, "SpectralFunctionKw");
   _add_type(_c2py_cls_1, "SpectralFunctionW");
 #undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
+  register_h5_type<_c2py_cls_1>(register_class);
 
   return m;
 }

--- a/python/triqs_modest/utils/checkpoint.py
+++ b/python/triqs_modest/utils/checkpoint.py
@@ -7,9 +7,12 @@ Wraps CheckpointBase (the c2py-exposed C++ class) and adds:
 - Keyword-extras written alongside required iteration data (master only)
 - restart() broadcasts last iteration to all ranks (collective)
 - Full Python iteration, indexing, and len() support
+- summarize() prints a convergence log of mu and orbital-resolved occupations
 """
 
 import os
+import sys
+import numpy as np
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 from .file_io import CheckpointBase, IterationData
@@ -20,9 +23,13 @@ __all__ = ["Checkpointer", "IterationData"]
 class Checkpointer:
     """MPI-aware checkpoint manager for DMFT calculations.
 
-    Enforces saving the minimal restart set (mu, Sigma_imp_list, Sigma_hartree_list)
-    per iteration and optionally stores additional quantities (Green's functions,
-    density matrices, etc.) in the same HDF5 group via keyword arguments.
+    Stores per iteration the restart-required self-energies (``mu``,
+    ``Sigma_imp_list``, ``Sigma_hartree_list``) along with optional inputs
+    (``Gloc_list``, ``Delta_list``) and outputs (``Gimp_list``,
+    ``Sigma_dc_list``) of the impurity solve. The optional fields default
+    to empty lists — simple DMFT runs can ignore them; CSC and ML workflows
+    fill them in. Anything else can still be passed through ``**extras``
+    and written to the same HDF5 group via ``HDFArchive``.
 
     All methods are safe to call on all MPI ranks — no ``is_master_node()`` guards
     required in user code. Only the master process performs HDF5 file I/O.
@@ -41,23 +48,28 @@ class Checkpointer:
 
     .. code-block:: python
 
-        chkpt    = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding" : E})
-        last     = chkpt.restart()          # collective — data on all ranks
+        chkpt = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding": E})
+        last  = chkpt.restart()              # collective — data on all ranks
         if last is not None:
             Sigma_dyn    = last.Sigma_imp_list[0]
             Sigma_static = last.Sigma_hartree_list[0]
+            Sigma_dc     = last.Sigma_dc_list[0] if last.Sigma_dc_list else None
         else:
             Sigma_dyn, Sigma_static = make_zero_self_energies(mesh)
+            Sigma_dc = None
 
         it_shift = len(chkpt)
 
         for n in range(it_shift, n_loops):
             ...
-            chkpt.append(
-                IterationData(mu=mu, Sigma_imp_list=[Sigma_dyn],
-                              Sigma_hartree_list=[Sigma_static]),
-                Delta_iw=Delta, Gimp_iw=Gimp, dm=dm,
-            )
+            chkpt.append(IterationData(
+                mu=mu,
+                Sigma_imp_list=[Sigma_dyn], Sigma_hartree_list=[Sigma_static],
+                Gimp_list=[Gimp], Sigma_dc_list=[Sigma_dc] if Sigma_dc is not None else [],
+                Gloc_list=[Gloc], Delta_list=[Delta],
+            ))
+
+        chkpt.summarize()                    # print a convergence log
     """
 
     def __init__(self, dirname, initial_data=None) -> None:
@@ -97,8 +109,14 @@ class Checkpointer:
         """Return last iteration data on all MPI ranks, or None if empty.
 
         Collective operation — all ranks must call this together. Master reads
-        from disk; components (mu, Sigma_imp_list, Sigma_hartree_list) are
-        broadcast individually to all ranks.
+        from disk; the returned ``IterationData`` is broadcast to all ranks.
+
+        Carries the restart-relevant fields: ``mu``, ``Sigma_imp_list``,
+        ``Sigma_hartree_list``, and ``Sigma_dc_list``. The DC list is ``[]``
+        for non-CSC runs and populated for CSC; callers can detect with
+        ``if it.Sigma_dc_list:``. Diagnostic fields (``Gimp_list``,
+        ``Gloc_list``, ``Delta_list``) are not in the restart payload — read
+        them via ``chkpt[i]`` on master or via ``summarize()``.
 
         Returns
         -------
@@ -112,12 +130,82 @@ class Checkpointer:
 
         iter_data = None
         if mpi.is_master_node():
-            mu             = self._cpp[-1].mu                
-            Sigma_imp_list = self._cpp[-1].Sigma_imp_list    
-            Sigma_H_list   = self._cpp[-1].Sigma_hartree_list
-            iter_data = IterationData(mu=mu, Sigma_imp_list=Sigma_imp_list, Sigma_hartree_list=Sigma_H_list)
+            last = self._cpp[-1]
+            iter_data = IterationData(
+                mu=last.mu,
+                Sigma_imp_list=last.Sigma_imp_list,
+                Sigma_hartree_list=last.Sigma_hartree_list,
+                Sigma_dc_list=last.Sigma_dc_list,
+            )
         iter_data = mpi.bcast(iter_data)
         return iter_data
+
+
+    def summarize(self, file=None) -> None:
+        """Print a per-iteration convergence log (master only).
+
+        Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+        occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+        skipped if no iteration in the checkpoint has the corresponding list
+        populated. Iterations whose individual lists are empty show ``--``
+        placeholders.
+
+        Parameters
+        ----------
+        file : file-like, optional
+            Destination stream; defaults to ``sys.stdout``.
+        """
+        if not mpi.is_master_node(): return
+        if file is None: file = sys.stdout
+
+        n_iter = len(self._cpp)
+        if n_iter == 0:
+            print("Checkpointer: no iterations stored.", file=file)
+            return
+
+        iters = [self._cpp[n] for n in range(n_iter)]
+
+        def orbital_layout(blocklist):
+            """Return [(imp_idx, block_name, orb_idx), ...] from the first non-empty list, or []."""
+            for it in iters:
+                lst = blocklist(it)
+                if lst:
+                    layout = []
+                    for i, bgf in enumerate(lst):
+                        for bn, g in bgf:
+                            for a in range(g.target_shape[0]):
+                                layout.append((i, bn, a))
+                    return layout
+            return []
+
+        imp_layout = orbital_layout(lambda it: it.Gimp_list)
+        loc_layout = orbital_layout(lambda it: it.Gloc_list)
+
+        headers = ["iter", "mu"]
+        headers += [f"n_imp{i}_{bn}_{a}_imp" for (i, bn, a) in imp_layout]
+        headers += [f"n_imp{i}_{bn}_{a}_loc" for (i, bn, a) in loc_layout]
+        widths = [max(len(h), 12) for h in headers]
+
+        def fmt_row(cells):
+            return "  ".join(f"{c:>{w}}" for c, w in zip(cells, widths))
+
+        print(fmt_row(headers), file=file)
+        print("  ".join("-" * w for w in widths), file=file)
+
+        def diag_occupations(blocklist, layout):
+            if not blocklist:
+                return ["--"] * len(layout)
+            diags = {}
+            for i, bgf in enumerate(blocklist):
+                for bn, g in bgf:
+                    diags[(i, bn)] = np.diag(g.density()).real
+            return [f"{diags[(i, bn)][a]:.6f}" for (i, bn, a) in layout]
+
+        for n, it in enumerate(iters):
+            row = [str(n), f"{it.mu:.6f}"]
+            row += diag_occupations(it.Gimp_list, imp_layout)
+            row += diag_occupations(it.Gloc_list, loc_layout)
+            print(fmt_row(row), file=file)
 
 
     @property

--- a/python/triqs_modest/utils/file_io.wrap.cxx
+++ b/python/triqs_modest/utils/file_io.wrap.cxx
@@ -15,6 +15,7 @@
 #define C2PY_VERSION_MINOR 1
 
 #include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
 
 using c2py::operator""_a;
 
@@ -44,14 +45,18 @@ static int synth_constructor_0(PyObject *self, PyObject *args, PyObject *kwargs)
   de("mu", self_c.mu, false);
   de("Sigma_imp_list", self_c.Sigma_imp_list, false);
   de("Sigma_hartree_list", self_c.Sigma_hartree_list, false);
+  de("Gimp_list", self_c.Gimp_list, true);
+  de("Sigma_dc_list", self_c.Sigma_dc_list, true);
+  de("Gloc_list", self_c.Gloc_list, true);
+  de("Delta_list", self_c.Delta_list, true);
   return de.check();
 }
 
 template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = synth_constructor_0;
 
 template <>
-const std::string c2py::tp_ctor_doc<_c2py_cls_0> =
-   c2py::replace_tags(R"DOC(Synthesized constructor with the following keyword arguments:
+const std::string c2py::tp_ctor_doc<_c2py_cls_0> = c2py::replace_tags(
+   R"DOC(Synthesized constructor with the following keyword arguments:
 
 Parameters
 ----------
@@ -61,27 +66,47 @@ Sigma_imp_list : {par_1}
 
 Sigma_hartree_list : {par_2}
 
+Gimp_list : {par_3}, default={}
+
+Sigma_dc_list : {par_4}, default={}
+
+Gloc_list : {par_5}, default={}
+
+Delta_list : {par_6}, default={}
+
 )DOC",
-                      "par",
-                      {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
-                       c2py::python_typename<std::vector<triqs::modest::block_mat_t>>()});
+   "par",
+   {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>()});
 
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
 constexpr auto _c2py_doc_member_0 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_1 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_2 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_3 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_4 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_5 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_6 = R"DOC()DOC";
 static PyObject *prop_get_dict_0(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
   c2py::pydict dic;
   dic["mu"]                 = self_c.mu;
   dic["Sigma_imp_list"]     = self_c.Sigma_imp_list;
   dic["Sigma_hartree_list"] = self_c.Sigma_hartree_list;
+  dic["Gimp_list"]          = self_c.Gimp_list;
+  dic["Sigma_dc_list"]      = self_c.Sigma_dc_list;
+  dic["Gloc_list"]          = self_c.Gloc_list;
+  dic["Delta_list"]         = self_c.Delta_list;
   return dic.new_ref();
 }
 
@@ -92,12 +117,21 @@ constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {
    c2py::getsetdef_from_member<&_c2py_cls_0::mu, _c2py_cls_0>("mu", _c2py_doc_member_0),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_imp_list, _c2py_cls_0>("Sigma_imp_list", _c2py_doc_member_1),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_hartree_list, _c2py_cls_0>("Sigma_hartree_list", _c2py_doc_member_2),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gimp_list, _c2py_cls_0>("Gimp_list", _c2py_doc_member_3),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_dc_list, _c2py_cls_0>("Sigma_dc_list", _c2py_doc_member_4),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gloc_list, _c2py_cls_0>("Gloc_list", _c2py_doc_member_5),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Delta_list, _c2py_cls_0>("Delta_list", _c2py_doc_member_6),
    {"__dict__", (getter)prop_get_dict_0, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
 template <>
-const std::string c2py::tp_doc<_c2py_cls_0> =
-   R"DOC(Minimal iteration data required to restart a DMFT loop.)DOC" + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
+const std::string c2py::tp_doc<_c2py_cls_0> = R"DOC(Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+
+The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+(`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+empty vectors so callers only fill what they have.)DOC"
+   + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
 // --------- class _c2py_cls_1 -----------
 using _c2py_cls_1                                            = triqs::modest::checkpoint<triqs::modest::iteration_data>;
 template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
@@ -197,6 +231,12 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_file_io() {
   _add_type(_c2py_cls_0, "IterationData");
   _add_type(_c2py_cls_1, "CheckpointBase");
 #undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
 
   return m;
 }

--- a/test/c++/load_data_test.cpp
+++ b/test/c++/load_data_test.cpp
@@ -52,7 +52,7 @@ TEST(load_data_tests, obe_high_symm_path) {
 TEST(load_data_tests, obe_parproj) {
   auto [_, obe] = one_body_elements_from_dft_converter("ref_data/SrVO3-cubic-t2g.ref.h5");
   std::cout << obe << std::endl;
-  auto obe_dos = one_body_elements_with_theta_projectors("ref_data/SrVO3-cubic-t2g.ref.h5", obe);
+  auto obe_dos = one_body_elements_with_partial_projectors("ref_data/SrVO3-cubic-t2g.ref.h5", obe);
   std::cout << obe_dos << std::endl;
 }
 

--- a/test/c++/mpi_test.cpp
+++ b/test/c++/mpi_test.cpp
@@ -33,13 +33,13 @@ TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithHighSymmPath) {
   EXPECT_EQ(obe2, ref_obe_bands);
 }
 
-TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithThetaProjectors) {
+TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithPartialProjectors) {
   std::string const filename = "ref_data/SrVO3-cubic-t2g.ref.h5";
   auto [target_density, obe] = one_body_elements_from_dft_converter(filename);
   // implicity reads on rank 0 and broadcasts
-  auto obe2 = one_body_elements_with_theta_projectors(filename, obe);
+  auto obe2 = one_body_elements_with_partial_projectors(filename, obe);
   // read on all ranks the data
-  auto ref_obe = read_theta_projectors_for_obe(filename, obe);
+  auto ref_obe = read_partial_projectors_for_obe(filename, obe);
   EXPECT_EQ(obe2, ref_obe);
 }
 

--- a/test/c++/obe_tb_test.cpp
+++ b/test/c++/obe_tb_test.cpp
@@ -52,14 +52,14 @@ TEST(obe_tb, lco_wannier90) { // NOLINT
 
   // run gloc, forcing gloc to use PTR on the same grid as the DFT calculation was done
   bz_int_options opt = {.k_grid = {7, 7, 7}, .k_grid_max = {7, 7, 7}, .run_adaptive = false};
-  auto gloc_tb                       = gloc(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
+  auto gloc_tb       = gloc(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
 
   // Check equivalence
   for (auto iw : iw_mesh) { EXPECT_COMPLEX_NEAR(gloc_tb(0, 0)[iw](0, 0), gloc_dft(0, 0)[iw](0, 0), 1e-5); }
 
   // density calculation for one spin channel, using the function which takes self energy and also the function assuming zero self energy
-  double n = density(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
-  double n_zero_sigma = density(obe_tb, mu_dft, iw_mesh, opt); 
+  double n            = density(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
+  double n_zero_sigma = density(obe_tb, mu_dft, iw_mesh, opt);
   EXPECT_NEAR(n, 1.0, 1e-4);
   EXPECT_NEAR(n_zero_sigma, 1.0, 1e-4);
 
@@ -100,10 +100,10 @@ TEST(obe_tb, svo_t2g_wannier90_multiorbtial) { // NOLINT
 
   // run gloc, forcing gloc to use PTR on the same grid as the DFT calculation was done
   bz_int_options opt = {.k_grid = {5, 5, 5}, .k_grid_max = {5, 5, 5}, .run_adaptive = false};
-  auto gloc_tb                       = gloc(iw_mesh, obe_tb, mu_dft, opt);
+  auto gloc_tb       = gloc(iw_mesh, obe_tb, mu_dft, opt);
 
-  // NOTE: The first frequency point here does not agree exactly, likely due to a small 
-  // difference in the Wannier H vs. the DFT data. 
+  // NOTE: The first frequency point here does not agree exactly, likely due to a small
+  // difference in the Wannier H vs. the DFT data.
   // This may also be due to the fact that DFT mesh was on [-0.5,0.5), and the PTR integration is 0,1
   for (auto iw : iw_mesh) { //
     if (std::abs(dcomplex(iw.value())) < 1.7) {


### PR DESCRIPTION
## Summary

Three small independent improvements to the obe / post-processing interface: a
terminology rename that brings the code in line with the documentation, `operator<<` and
HDF5 I/O for structs that were missing them, and one more c++ function exposed to
Python.


This provides an **incremental diff:**
[`pr/checkpoint-summarize...pr/obe-printing-h5`](https://github.com/harrisonlabollita/modest/compare/pr/checkpoint-summarize...pr/obe-printing-h5)


## Changes

### 1. `theta` projector → `partial` projector (`da5248b`)

The documentation call it a partial projector, while the code called it `theta`. To be consistent between the two, I've renamed throughout `loaders.{hpp,cpp}` and `postprocess.{hpp,cpp}`. This should improve readability and clarity.

**Public Python API change:**
`one_body_elements_with_theta_projectors` → `one_body_elements_with_partial_projectors`
(`python/triqs_modest/obe.toml`). Needs a `ChangeLog.md` entry.

Additional changes in this PR:
- `h5_read` / `h5_write` for `spectral_function_kw` and `spectral_function_w`
  (`h5.cpp`) — these results were previously not serializable.
- `operator<<` for the post-process structs (`printing.cpp`).
- Rename propagated through `load_data_test.cpp` and `mpi_test.cpp`.

### 2. `operator<<` for the remaining OBE structs (`f318fba`)

Adds printing for `one_body_elements_tb` and `one_body_elements_gw`, so every OBE
variant is now printable. `printing.cpp` picks up an `obe_tb.hpp` include.

### 3. Expose `rotate_local_basis` (`05af10e`)

Added to the `obe` c2py spec so the local-basis rotation that the post-processing
routines apply internally is reachable from Python. Documented in
`doc/reference/python/one_body_elements.rst`.

## Testing

Existing tests only; `load_data_test`, `mpi_test` and `obe_tb_test` are updated
for the rename and pass. 