### PR TITLE
Rework `projected_spectral_function`, add tight-binding post-processing

### DIFF
--- a/c++/triqs_modest/chargedensity.hpp
+++ b/c++/triqs_modest/chargedensity.hpp
@@ -24,25 +24,42 @@ namespace triqs::modest {
                                                     block2_gf<Mesh, matrix_valued> const &Sigma_dynamic,
                                                     nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
 
-    auto n_sigma = obe.C_space.n_sigma(); // number of spin channesl
-    auto n_k     = obe.H.n_k();           // number of k-points
+    auto n_sigma = obe.C_space.n_sigma();
+    auto n_k     = obe.H.n_k();
 
-    // maximum number of bands
-    auto n_nu_k = range(n_k) | stdv::transform([&obe](auto k_idx) { return obe.H.N_nu(0, k_idx); }) | tl::to<std::vector>();
-    auto n_nu   = *std::max_element(begin(n_nu_k), end(n_nu_k));
-
-    // setup data structure for return
+    // Output: band-basis density matrix per (k, σ).  Use n_nu = max over k of N_ν(0, k).
+    auto n_nu_k     = range(n_k) | stdv::transform([&obe](auto k_idx) { return obe.H.N_nu(0, k_idx); }) | tl::to<std::vector>();
+    auto n_nu       = *std::max_element(begin(n_nu_k), end(n_nu_k));
     auto N_nu_nup_k = nda::zeros<dcomplex>(n_k, n_sigma, n_nu, n_nu);
 
-    // calculator for lattice Green's function at given k and σ
-    auto glatt_at_k = detail::lattice_gf_at_k(obe, mu, Sigma_dynamic, Sigma_static);
+    // Matrix-valued H(k): direct N_ν × N_ν inversion fallback (no rank-reduction benefit).
+    if (obe.H.matrix_valued) {
+      auto glatt_at_k = detail::lattice_gf_at_k(obe, mu, Sigma_dynamic, Sigma_static);
+#pragma omp parallel for collapse(2) default(none) shared(n_k, n_sigma, obe, glatt_at_k, N_nu_nup_k, r_all)
+      for (auto k_idx : range(n_k)) {
+        for (auto sigma : range(n_sigma)) {
+          auto r_window                                = nda::range(0, obe.H.N_nu(sigma, k_idx));
+          N_nu_nup_k(k_idx, sigma, r_window, r_window) = density(glatt_at_k(k_idx, sigma));
+        }
+      }
+      return N_nu_nup_k;
+    }
 
-    // loop over k and σ
-    // TODO: parallelize over k and gather
+    // Diagonal H(k): rank-reduced Woodbury, band-basis G_k built per (k, σ, ω)
+    auto const &mesh = Sigma_dynamic(0, 0).mesh();
+    auto wb          = detail::make_woodbury_setup(Sigma_dynamic, Sigma_static);
+
+#pragma omp parallel for collapse(2) default(none) shared(n_k, n_sigma, mesh, obe, mu, wb, N_nu_nup_k, r_all)
     for (auto k_idx : range(n_k)) {
-      for (auto const &sigma : range(n_sigma)) {
-        auto r_window                                = nda::range(0, obe.H.N_nu(sigma, k_idx));
-        N_nu_nup_k(k_idx, sigma, r_window, r_window) = density(glatt_at_k(k_idx, sigma));
+      for (auto sigma : range(n_sigma)) {
+        auto N_nu_k = obe.H.N_nu(sigma, k_idx);
+
+        // Build G_k(ω) in the band basis via Woodbury, then call density() on it.
+        auto Glatt   = gf{mesh, std::array<long, 2>{N_nu_k, N_nu_k}};
+        Glatt.data() = detail::build_G_band(obe, wb.active, wb.Sa_per_sigma[sigma], wb.omegas, mu, k_idx, sigma);
+
+        auto r_window                                = nda::range(0, N_nu_k);
+        N_nu_nup_k(k_idx, sigma, r_window, r_window) = density(Glatt);
       }
     }
 

--- a/c++/triqs_modest/chargedensity.hpp
+++ b/c++/triqs_modest/chargedensity.hpp
@@ -3,7 +3,7 @@
 #include "utils/gf_supp.hpp"
 #include <triqs/mesh.hpp>
 #include "downfolding.hpp"
-#include "gloc_fixed_grid.hpp"
+#include "./lattice_gf_helpers.hpp"
 
 namespace triqs::modest {
 

--- a/c++/triqs_modest/checkpoint.hpp
+++ b/c++/triqs_modest/checkpoint.hpp
@@ -21,33 +21,69 @@ namespace triqs::modest {
   using block_mat_t       = std::vector<nda::matrix<dcomplex>>;
 
   /**
-   * @brief Minimal iteration data required to restart a DMFT loop.
+   * @brief Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+   *
+   * The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+   * from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+   * (`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+   * empty vectors so callers only fill what they have.
    */
   struct iteration_data {
     double mu;
+
+    // restart-required outputs
     std::vector<block_gf_imfreq_t> Sigma_imp_list;
     std::vector<block_mat_t> Sigma_hartree_list;
+
+    // additional outputs (optional)
+    std::vector<block_gf_imfreq_t> Gimp_list = {};
+    std::vector<block_mat_t> Sigma_dc_list   = {}; // CSC double-counting self-energy
+
+    // inputs (optional)
+    std::vector<block_gf_imfreq_t> Gloc_list  = {};
+    std::vector<block_gf_imfreq_t> Delta_list = {};
+
+    static std::string hdf5_format() { return "IterationData"; }
 
     C2PY_IGNORE friend void mpi_broadcast(iteration_data &x, mpi::communicator c = {}, int root = 0) {
       mpi::broadcast(x.mu, c, root);
       mpi::broadcast(x.Sigma_imp_list, c, root);
       mpi::broadcast(x.Sigma_hartree_list, c, root);
+      mpi::broadcast(x.Gimp_list, c, root);
+      mpi::broadcast(x.Sigma_dc_list, c, root);
+      mpi::broadcast(x.Gloc_list, c, root);
+      mpi::broadcast(x.Delta_list, c, root);
     }
   };
 
-  // HDF5 serialization for iteration_data
+  // HDF5 serialization for iteration_data. Layout:
+  //   <name>/mu
+  //   <name>/inputs/{Gloc_list, Delta_list}
+  //   <name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list, Sigma_dc_list}
   inline void h5_write(h5::group g, std::string const &name, iteration_data const &data) {
     auto g2 = g.create_group(name);
     h5::write(g2, "mu", data.mu);
-    h5::write(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::write(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.create_group("inputs");
+    h5::write(g_in, "Gloc_list", data.Gloc_list);
+    h5::write(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.create_group("outputs");
+    h5::write(g_out, "Gimp_list", data.Gimp_list);
+    h5::write(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::write(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::write(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   inline void h5_read(h5::group g, std::string const &name, iteration_data &data) {
     auto g2 = g.open_group(name);
     h5::read(g2, "mu", data.mu);
-    h5::read(g2, "Sigma_imp_list", data.Sigma_imp_list);
-    h5::read(g2, "Sigma_hartree_list", data.Sigma_hartree_list);
+    auto g_in = g2.open_group("inputs");
+    h5::read(g_in, "Gloc_list", data.Gloc_list);
+    h5::read(g_in, "Delta_list", data.Delta_list);
+    auto g_out = g2.open_group("outputs");
+    h5::read(g_out, "Gimp_list", data.Gimp_list);
+    h5::read(g_out, "Sigma_imp_list", data.Sigma_imp_list);
+    h5::read(g_out, "Sigma_hartree_list", data.Sigma_hartree_list);
+    h5::read(g_out, "Sigma_dc_list", data.Sigma_dc_list);
   }
 
   // ===========================================================================
@@ -73,8 +109,7 @@ namespace triqs::modest {
     /// Open existing or create new checkpoint directory.
     checkpoint(std::string dirname) : _dirname{dirname}, _iter_file{dirname + "/iterations.h5"} {
       if (fs::exists(dirname)) {
-        if (!fs::is_directory(dirname))
-          throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
+        if (!fs::is_directory(dirname)) throw std::runtime_error{fmt::format("Checkpoint: '{}' exists but is not a directory", dirname)};
         auto file = h5::file(_iter_file, 'r');
         _n_iter   = long(h5::group{file}.get_all_subgroup_dataset_names().size());
       } else {

--- a/c++/triqs_modest/density.hpp
+++ b/c++/triqs_modest/density.hpp
@@ -10,6 +10,7 @@
 #include <itertools/omp_chunk.hpp>
 #include <triqs/lattice/brillouin_zone.hpp>
 #include "./downfolding.hpp"
+#include "./lattice_gf_helpers.hpp"
 #include <triqs/experimental/utility/root_finder.hpp>
 
 namespace triqs::modest {
@@ -148,36 +149,25 @@ namespace triqs::modest {
   template <typename Mesh>
   double density_for_matrix_valued_impl(one_body_elements_on_grid const &obe, double mu, block2_gf<Mesh, matrix_valued> const &Sigma_dynamic,
                                         nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
-    // nda::array<nda::matrix<double>, 2> const &Sigma_DC) {
     auto const &mesh = Sigma_dynamic(0, 0).mesh();
     auto beta        = mesh.beta();
+    auto result      = gf{mesh}; // tr(G_full − G_KS) per ω, summed over (k, σ).
 
-    auto result = gf{mesh}; // Compute the correction term on all dlr mesh points
+    // Reuse the direct N_ν × N_ν inversion helper.  Returns a callable (k, σ) → gf on (mesh, {N_ν, N_ν}).
+    auto glatt_at_k = detail::lattice_gf_at_k(obe, mu, Sigma_dynamic, Sigma_static);
 
-    auto PSP = [&](auto &iw, auto &k_idx, auto &sigma) {
-      auto N_nu             = obe.H.N_nu(sigma, k_idx);
-      auto out              = nda::zeros<dcomplex>(N_nu, N_nu);
-      auto embedding_decomp = get_struct(Sigma_dynamic).dims(r_all, 0) | tl::to<std::vector>();
-      for (auto &&[alpha, R] : enumerated_sub_slices(embedding_decomp)) {
-        auto P = obe.P.P(sigma, k_idx)(R, r_all);
-        out(r_all, r_all) += dagger(P) * nda::matrix<dcomplex>{Sigma_dynamic(alpha, sigma).data()(iw, r_all, r_all) + Sigma_static(alpha, sigma)} * P;
-      }
-      return out;
-    };
-
-    auto Glatt = [&](auto &k_idx, auto &sigma) {
-      using nda::linalg::inv;
-      auto out = gf{mesh};
-      for (auto &&[n, w] : enumerate(mesh)) {
-        out.data()(n) = trace(inv(w + mu - obe.H.H(sigma, k_idx) - PSP(n, k_idx, sigma)) - inv(w + mu - obe.H.H(sigma, k_idx)));
-      }
-      return out;
-    };
-
-    mpi::communicator comm = {}; // for now using default comm in MPI
-#pragma omp parallel for collapse(2) reduction(gf_sum : result) default(none) shared(obe, Glatt, comm)
+    mpi::communicator comm = {};
+#pragma omp parallel for collapse(2) reduction(gf_sum : result) default(none) shared(obe, mu, mesh, glatt_at_k, comm, r_all)
     for (auto k_idx : mpi::chunk(range(obe.H.n_k()), comm)) {
-      for (auto sigma : range(obe.C_space.n_sigma())) { result.data() += obe.H.k_weights(k_idx) * Glatt(k_idx, sigma).data(); }
+      for (auto sigma : range(obe.C_space.n_sigma())) {
+        using nda::linalg::inv;
+        auto G_band = glatt_at_k(k_idx, sigma); // gf on (mesh, {N_ν, N_ν})
+        auto Hk     = obe.H.H(sigma, k_idx);
+        for (auto &&[n, w] : enumerate(mesh)) {
+          result.data()(n) += obe.H.k_weights(k_idx)
+             * (trace(G_band.data()(n, r_all, r_all)) - trace(inv(nda::matrix<dcomplex>{w + mu - Hk})));
+        }
+      }
     }
     result = mpi::all_reduce(result);
     return density_nk(obe, mu, beta) + real(density(result));

--- a/c++/triqs_modest/density.hpp
+++ b/c++/triqs_modest/density.hpp
@@ -4,7 +4,6 @@
 // See LICENSE in the root of this distribution for details.
 
 #pragma once
-//#include <mpi/generic_communication.hpp>
 #include <nda/nda.hpp>
 #include <triqs/gfs.hpp>
 #include <itertools/omp_chunk.hpp>
@@ -18,64 +17,53 @@ namespace triqs::modest {
 #pragma omp declare reduction(gf_sum : gf<imfreq, scalar_valued> : omp_out += omp_in) initializer(omp_priv = gf{omp_orig.mesh()})
 #pragma omp declare reduction(gf_sum : gf<dlr_imfreq, scalar_valued> : omp_out += omp_in) initializer(omp_priv = gf{omp_orig.mesh()})
 
-  // ============================================
-  namespace detail {
-    // impl detail : compute (1- Y1 Sigma)^{-1} Y2 in M x M space, with Sigma by block
-    nda::matrix<dcomplex, nda::F_layout> calc_inv_G_G0(long M, auto embedding_decomp, auto const &Sigma_dynamic, auto const &Sigma_static, auto om,
-                                                       long sigma, nda::matrix_view<dcomplex> Y1, nda::matrix_view<dcomplex> Y2) {
-      // Y Sigma. NB Sigma is by blocks.
-      // NB: F_layout because of getrs in Ainv_B below
-      auto YS = nda::matrix<dcomplex, nda::F_layout>::zeros(M, M);
+  //-------------------------------------------------------------------------------------------
+  /** @cond DOXYGEN_SKIP_THIS */
+  /// Density at a fixed μ from an already-built (μ-independent) Woodbury setup.
+  template <typename Mesh> double density_impl(one_body_elements_on_grid const &obe, double mu, Mesh const &mesh, detail::woodbury_setup const &wb) {
 
-      for (auto &&[alpha, R] : enumerated_sub_slices(embedding_decomp)) {
-        auto Sigma = nda::matrix<dcomplex>{Sigma_dynamic(alpha, sigma)[om] + Sigma_static(alpha, sigma)};
-        nda::blas::gemm(-1, Y1(r_all, R), Sigma, 0, YS(r_all, R));
-      }
+    double beta    = mesh.beta();
+    auto n_sigma   = long(wb.Sa_per_sigma.size());
+    auto n_w       = long(wb.omegas.size());
+    auto n_k       = obe.H.n_k();
+    auto corr      = gf{mesh}; // Compute the correction term on all dlr mesh points
+    double KS_term = 0;        // The first Kohn Sham term, cf Notes
 
-      // Z = (1 -YS)^{-1} * Y
-      for (auto m : range(M)) YS(m, m) += 1;
-      auto B = nda::matrix<dcomplex, nda::F_layout>{Y2(r_all, r_all)};
-      //B      = inverse(YS) * B;
-      Ainv_B(YS, B);
-      return B;
-    }
+    // OP : we don't have a Fermi function in TRIQS ??
+    auto Fermi = [](double x) { return (x > 0 ? exp(-x) / (1 + exp(-x)) : 1 / (1 + exp(x))); };
 
-    //-------------------------------------------------------------------------------------------
-    // Returns a lambda (sigma, k_idx ) -> [Tr_nu G_B(k, omega) - Tr_nu G_KS(k, omega) for omega in Sigma.mesh] as nda::array
-    template <typename Mesh>
-    auto trace_G_B_m_G_KS(one_body_elements_on_grid const &obe, double mu,
-                          // add magnetic field,
-                          block2_gf<Mesh, matrix_valued> const &Sigma_dynamic, nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
+    mpi::communicator comm = {};
+#pragma omp parallel for collapse(2) reduction(gf_sum : corr) reduction(+ : KS_term) default(none)                                                   \
+   shared(comm, r_all, n_k, n_sigma, n_w, obe, mu, beta, Fermi, wb)
+    for (auto k_idx : mpi::chunk(range(n_k), comm)) {
+      for (auto sigma : range(n_sigma)) {
+        // 1- Kohn-Sham term (unchanged).
+        double KS_term_acc = 0;
+        auto eps           = obe.H.H(sigma, k_idx);
+        for (auto nu : range(obe.H.N_nu(sigma, k_idx))) KS_term_acc += Fermi(beta * real(eps(nu, nu) - mu));
+        KS_term += obe.H.k_weights(k_idx) * KS_term_acc;
 
-      auto M                = obe.C_space.dim();
-      auto &mesh            = Sigma_dynamic(0, 0).mesh();
-      auto omegas           = mesh | tl::to<std::vector<dcomplex>>();
-      auto embedding_decomp = get_struct(Sigma_dynamic).dims(r_all, 0) | tl::to<std::vector>();
+        // 2- Correction term:  tr(G_band − M₀⁻¹) = tr(K · G0_QQ_sq) per (k, σ, ω).
+        //    Σ ≡ 0 ⇒ correction is exactly zero, leaving density = KS_term.
+        if (wb.active.rank == 0) continue;
 
-      return [=, &obe, &Sigma_dynamic, &Sigma_static](long sigma, long k_idx) {
-        auto result = nda::zeros<dcomplex>(omegas.size());
-        auto Y1     = detail::G0_C_k_sigma(obe, mu, k_idx, sigma, omegas, false); // Y1 = G0_𝓒
-        auto Y2     = detail::G0_C_k_sigma(obe, mu, k_idx, sigma, omegas, true);  // Y2 = + ∂_μ G0_𝓒
+        auto bare        = detail::compute_bare_projected(obe, obe.P, mu, k_idx, sigma, wb.omegas, wb.active);
+        auto const &Sa_n = wb.Sa_per_sigma[sigma];
+        auto w_k         = obe.H.k_weights(k_idx);
 
-        for (auto &&[n, om] : itertools::enumerate(mesh)) {
-          // Compute (1- Y1 Sigma)^{-1} Y2
-          auto B = calc_inv_G_G0(M, embedding_decomp, Sigma_dynamic, Sigma_static, om, sigma, Y1(n, r_all, r_all), Y2(n, r_all, r_all));
-
-          // Tr (Sigma * B)
-          dcomplex tr_Sigma_B = 0;
-          for (auto &&[alpha, R] : enumerated_sub_slices(embedding_decomp)) {
-            auto [m, mp] = Sigma_dynamic(alpha, sigma).target_shape();
-            auto A       = Sigma_dynamic(alpha, sigma).data()(n, r_all, r_all) + Sigma_static(alpha, sigma);
-            auto C       = B(R, R);
-            for (auto m1 : range(m))
-              for (auto m2 : range(mp)) tr_Sigma_B += A(m1, m2) * C(m2, m1);
-          }
-          result(n) -= obe.H.k_weights(k_idx) * tr_Sigma_B;
+        for (auto n : range(n_w)) {
+          auto Sa     = nda::matrix<dcomplex>{Sa_n(n, r_all, r_all)};
+          auto Yaa    = nda::matrix<dcomplex>{bare.G0_QQ(n, r_all, r_all)};
+          auto K_QQsq = detail::apply_K(Sa, Yaa, bare.G0_QQ_sq(n, r_all, r_all)); // K · G0_QQ_sq
+          corr.data()(n) += w_k * nda::trace(K_QQsq);
         }
-        return result;
-      };
+      }
     }
-  } // namespace detail
+    KS_term = mpi::all_reduce(KS_term);
+    corr    = mpi::all_reduce(corr);
+    return KS_term + real(density(corr));
+  }
+  /** @endcond */
 
   //-------------------------------------------------------------------------------------------
   /**
@@ -95,39 +83,7 @@ namespace triqs::modest {
                  block2_gf<Mesh, matrix_valued> const &Sigma_dynamic, nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
 
     if (obe.H.matrix_valued) return density_for_matrix_valued_impl(obe, mu, Sigma_dynamic, Sigma_static);
-
-    auto n_sigma     = Sigma_dynamic.size2();
-    auto n_k         = obe.H.n_k();
-    auto const &mesh = Sigma_dynamic(0, 0).mesh();
-    double beta      = mesh.beta();
-    auto corr        = gf{mesh}; // Compute the correction term on all dlr mesh points
-    double KS_term   = 0;        // The first Kohn Sham term, cf Notes
-
-    // OP : we don't have a Fermi function in TRIQS ??
-    auto Fermi                = [](double x) { return (x > 0 ? exp(-x) / (1 + exp(-x)) : 1 / (1 + exp(x))); };
-    auto calc_correction_term = detail::trace_G_B_m_G_KS(obe, mu, Sigma_dynamic, Sigma_static);
-
-    // ---------
-    mpi::communicator comm = {}; // for now using default comm in MPI
-#pragma omp parallel for collapse(2) reduction(gf_sum : corr) reduction(+ : KS_term) default(none)                                                   \
-   shared(n_k, comm, n_sigma, obe, Fermi, mu, calc_correction_term, beta)
-    for (auto k_idx : mpi::chunk(range(n_k), comm)) {
-      for (auto sigma : range(n_sigma)) {
-
-        // 1- KS term
-        double KS_term_acc = 0;
-        auto eps           = obe.H.H(sigma, k_idx);
-        for (auto nu : range(obe.H.N_nu(sigma, k_idx)))        // we must cut at N_nu, do not add nu with eps =0
-          KS_term_acc += Fermi(beta * real(eps(nu, nu) - mu)); // FIXME : H SHOULD BE REAL in OBE !!
-        KS_term += obe.H.k_weights(k_idx) * KS_term_acc;
-
-        //  2- Correction term
-        corr.data() += calc_correction_term(sigma, k_idx);
-      }
-    }
-    KS_term = mpi::all_reduce(KS_term);
-    corr    = mpi::all_reduce(corr);
-    return KS_term + real(density(corr));
+    return density_impl(obe, mu, Sigma_dynamic(0, 0).mesh(), detail::make_woodbury_setup(Sigma_dynamic, Sigma_static));
   }
 
   // ------------------------------------------------------------------------------------
@@ -164,8 +120,7 @@ namespace triqs::modest {
         auto G_band = glatt_at_k(k_idx, sigma); // gf on (mesh, {N_ν, N_ν})
         auto Hk     = obe.H.H(sigma, k_idx);
         for (auto &&[n, w] : enumerate(mesh)) {
-          result.data()(n) += obe.H.k_weights(k_idx)
-             * (trace(G_band.data()(n, r_all, r_all)) - trace(inv(nda::matrix<dcomplex>{w + mu - Hk})));
+          result.data()(n) += obe.H.k_weights(k_idx) * (trace(G_band.data()(n, r_all, r_all)) - trace(inv(nda::matrix<dcomplex>{w + mu - Hk})));
         }
       }
     }
@@ -188,9 +143,10 @@ namespace triqs::modest {
    */
   inline double find_chemical_potential(double const target_density, one_body_elements_on_grid const &obe, double beta,
                                         std::string method = "dichotomy", double precision = 1.e-5, bool verbosity = true) {
-    mpi::communicator comm = {};
+    mpi::communicator comm          = {};
     std::function<double(double)> f = [&obe, beta](double x) { return density_nk(obe, x, beta); };
-    return std::get<0>(triqs::experimental::utility::root_finder(method, f, 0.0, target_density, precision, 0.5, 1000, "Chemical Potential", "Total Density", verbosity && comm.rank() == 0));
+    return std::get<0>(triqs::experimental::utility::root_finder(method, f, 0.0, target_density, precision, 0.5, 1000, "Chemical Potential",
+                                                                 "Total Density", verbosity && comm.rank() == 0));
   }
 
   /**
@@ -212,8 +168,16 @@ namespace triqs::modest {
                                  block2_gf<Mesh, matrix_valued> const &Sigma_dynamic, nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static,
                                  std::string method = "dichotomy", double precision = 1.e-5, bool verbosity = true) {
     mpi::communicator comm = {};
-    std::function<double(double)> f = [&obe, &Sigma_dynamic, &Sigma_static](double x) { return density(obe, x, Sigma_dynamic, Sigma_static); };
-    return std::get<0>(triqs::experimental::utility::root_finder(method, f, 0.0, target_density, precision, 0.5, 1000, "Chemical Potential", "Total Density", verbosity && comm.rank() == 0));
+    auto const &mesh       = Sigma_dynamic(0, 0).mesh();
+
+    std::function<double(double)> f;
+    if (obe.H.matrix_valued)
+      f = [&](double x) { return density_for_matrix_valued_impl(obe, x, Sigma_dynamic, Sigma_static); };
+    else // the Σ-derived setup is μ-independent: build it once, not once per root-finder iteration
+      f = [&, wb = detail::make_woodbury_setup(Sigma_dynamic, Sigma_static)](double x) { return density_impl(obe, x, mesh, wb); };
+
+    return std::get<0>(triqs::experimental::utility::root_finder(method, f, 0.0, target_density, precision, 0.5, 1000, "Chemical Potential",
+                                                                 "Total Density", verbosity && comm.rank() == 0));
   }
 
   /** @cond DOXYGEN_SKIP_THIS */

--- a/c++/triqs_modest/downfolding.cpp
+++ b/c++/triqs_modest/downfolding.cpp
@@ -152,13 +152,6 @@ namespace triqs::modest {
   }
   // -------------------------------------------------------------------------------------------
 
-  // fnt case to be implemented
-  //nda::array<nda::matrix<dcomplex>, 2> impurity_levels(one_body_elements const &one_body) {
-  //   // return H_k.get_R({0, 0, 0}); // GET R = 0 member.
-  // }
-
-  // -------------------------------------------------------------------------
-
   nda::array<dcomplex, 3> detail::G0_C_k_sigma(one_body_elements_on_grid const &obe, double mu, long k_idx, long sigma,
                                                std::vector<dcomplex> const &omegas, bool mu_derivative) {
     // Using Woodbury formula

--- a/c++/triqs_modest/downfolding.cpp
+++ b/c++/triqs_modest/downfolding.cpp
@@ -152,43 +152,4 @@ namespace triqs::modest {
   }
   // -------------------------------------------------------------------------------------------
 
-  nda::array<dcomplex, 3> detail::G0_C_k_sigma(one_body_elements_on_grid const &obe, double mu, long k_idx, long sigma,
-                                               std::vector<dcomplex> const &omegas, bool mu_derivative) {
-    // Using Woodbury formula
-
-    auto n_nu = obe.H.N_nu(sigma, k_idx);
-    auto R_nu = nda::range(n_nu);
-    auto M    = obe.C_space.dim();
-
-    // Compute Dinv(omega, nu) = 1/(om + mu - Hk(nu))
-    auto n_omega       = omegas.size();
-    auto Dinv          = nda::matrix<dcomplex>(n_omega, n_nu);
-    auto Hk            = obe.H.H(sigma, k_idx); // Hk[nu,nu']
-    constexpr auto sqr = [](auto x) { return x * x; };
-
-    // avoid the if in the inner loop
-    if (not mu_derivative) {
-      for (auto [n, om] : enumerate(omegas))
-        for (auto nu : R_nu) Dinv(n, nu) = 1 / (om + mu - Hk(nu, nu));
-    } else {
-      for (auto [n, om] : enumerate(omegas))
-        for (auto nu : R_nu) Dinv(n, nu) = -1 / sqr(om + mu - Hk(nu, nu));
-    }
-    // Compute M[nu, (alpha, m), (alpha', m')] = P[(alpha, m), nu ] conj(P)[(alpha', m'), nu ]
-    // Compute M[nu, m, m'] = P[m, nu ] conj(P)[m', nu ]
-    auto PP = nda::zeros<dcomplex>(n_nu, M, M);
-    auto P  = obe.P.P(sigma, k_idx);
-    for (auto m : range(M))
-      for (auto mp : range(M))
-        for (auto nu : R_nu) PP(nu, m, mp) = P(m, nu) * conj(P(mp, nu));
-
-    // Compute Y [ w, m, m'] = D[w, nu] * PP[nu, m,  m']
-    // Sum over nu  = matmul.
-    auto Y       = nda::zeros<dcomplex>(n_omega, M, M);
-    auto M_asmat = cmat_vt{nda::group_indices_view(PP, nda::idx_group<0>, nda::idx_group<1, 2>)};
-    auto Y_asmat = cmat_vt{nda::group_indices_view(Y, nda::idx_group<0>, nda::idx_group<1, 2>)};
-    nda::blas::gemm(1, Dinv, M_asmat, 0, Y_asmat);
-    return Y;
-  }
-
 } // namespace triqs::modest

--- a/c++/triqs_modest/downfolding.hpp
+++ b/c++/triqs_modest/downfolding.hpp
@@ -246,11 +246,4 @@ namespace triqs::modest {
   nda::array<nda::matrix<dcomplex>, 2> impurity_levels(one_body_elements_on_grid const &obe);
   // -------------------------------------------------------------
 
-  // These functions are not part of the public API: not documented, not wrapped.
-  namespace detail {
-    /// The projected bare function on the C space, cf notes.
-    nda::array<dcomplex, 3> G0_C_k_sigma(one_body_elements_on_grid const &obe, double mu, long k_idx, long sigma, std::vector<dcomplex> const &omegas,
-                                         bool mu_derivative = false);
-  } // namespace detail
-
 } // namespace triqs::modest

--- a/c++/triqs_modest/downfolding.hpp
+++ b/c++/triqs_modest/downfolding.hpp
@@ -219,6 +219,8 @@ namespace triqs::modest {
       mpi::broadcast(x.C_space, c, root);
       mpi::broadcast(x.P, c, root);
     }
+
+    friend std::ostream &operator<<(std::ostream &out, one_body_elements_gw const &x);
   };
 
   //-------------------------------------------------------------

--- a/c++/triqs_modest/gloc_fixed_grid.hpp
+++ b/c++/triqs_modest/gloc_fixed_grid.hpp
@@ -4,7 +4,6 @@
 // See LICENSE in the root of this distribution for details.
 
 #pragma once
-#include "./density.hpp"
 #include "./lattice_gf_helpers.hpp"
 #include <triqs/mesh.hpp>
 #include "utils/gf_supp.hpp"
@@ -90,37 +89,39 @@ namespace triqs::modest {
     // intercept if the dispersion in obe is matrix valued. The Woodbury offers no performance gain for this case.
     if (obe.H.matrix_valued) return gloc_for_matrix_valued_dispersion_impl(obe, mu, Sigma_dynamic, Sigma_static);
 
-    auto n_sigma     = Sigma_dynamic.size2();
-    auto M           = obe.C_space.dim();
-    auto n_kpts      = long(obe.H.n_k());
     auto const &mesh = Sigma_dynamic(0, 0).mesh();
+    auto n_sigma     = Sigma_dynamic.size2();
+    auto n_kpts      = long(obe.H.n_k());
     auto gloc_result = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
-    auto omegas      = mesh | tl::to<std::vector<dcomplex>>();
+    auto wb          = detail::make_woodbury_setup(Sigma_dynamic, Sigma_static);
+    auto n_w         = long(wb.omegas.size());
 
-    // Embedding decomposition from structure of Sigma
-    auto embedding_decomp = get_struct(Sigma_dynamic).dims(r_all, 0) | tl::to<std::vector>();
-
-    // ---------
-    // NOTE: Is there any reason why sigma loop should be the external one?
-    // Internal is favorable for maximum parallelization.
     mpi::communicator comm = {};
-#pragma omp parallel for collapse(2) reduction(block2_gf_sum : gloc_result) default(none)                                                            \
-   shared(comm, r_all, n_kpts, n_sigma, obe, mu, omegas, mesh, M, embedding_decomp, Sigma_dynamic, Sigma_static)
+#pragma omp parallel for collapse(2) reduction(block2_gf_sum : gloc_result) default(none) shared(comm, r_all, n_kpts, n_sigma, n_w, obe, mu, wb)
     for (auto k_idx : mpi::chunk(range(n_kpts), comm)) {
       for (auto sigma : range(n_sigma)) {
-        auto Y = detail::G0_C_k_sigma(obe, mu, k_idx, sigma, omegas, false);
-        for (auto &&[n, om] : itertools::enumerate(mesh)) {
-          auto Y1 = Y(n, r_all, r_all);
-          auto B  = detail::calc_inv_G_G0(M, embedding_decomp, Sigma_dynamic, Sigma_static, om, sigma, Y1, Y1);
-          gloc_result(0, sigma).data()(n, r_all, r_all) += obe.H.k_weights(k_idx) * B;
+        auto bare        = detail::compute_bare_projected(obe, obe.P, mu, k_idx, sigma, wb.omegas, wb.active);
+        auto const &Sa_n = wb.Sa_per_sigma[sigma];
+        auto w_k         = obe.H.k_weights(k_idx);
+
+        // Σ ≡ 0 short-circuit: G_loc^C = G0_PP, no correction.
+        if (wb.active.rank == 0) {
+          for (auto n : range(n_w)) gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * bare.G0_PP(n, r_all, r_all);
+          continue;
+        }
+
+        for (auto n : range(n_w)) {
+          // Rank-reduced Woodbury:  G_loc += w_k · ( G0_PP + L · K · R ), L = G0_PQ, R = G0_QPdag.
+          auto Sa      = nda::matrix<dcomplex>{Sa_n(n, r_all, r_all)};
+          auto Yaa     = nda::matrix<dcomplex>{bare.G0_QQ(n, r_all, r_all)};
+          auto KR      = detail::apply_K(Sa, Yaa, bare.G0_QPdag(n, r_all, r_all));
+          auto L_n     = nda::matrix<dcomplex>{bare.G0_PQ(n, r_all, r_all)};
+          auto contrib = nda::matrix<dcomplex>{bare.G0_PP(n, r_all, r_all) + L_n * KR};
+          gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * contrib;
         }
       }
-      // No normalization: the Pk are in obe ALREADY normalized.
     }
     gloc_result = mpi::all_reduce(gloc_result);
-
-    // FIXME :: the IBZ should work on a proper gf_view with atomic decomposition
-    // CHANGE IBZ accordingly ...
     if (auto const &S = obe.ibz_symm_ops; S) gloc_result = S->symmetrize(gloc_result, obe.C_space.atomic_decomposition());
     return gloc_result;
   }

--- a/c++/triqs_modest/gloc_fixed_grid.hpp
+++ b/c++/triqs_modest/gloc_fixed_grid.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 #include "./density.hpp"
+#include "./lattice_gf_helpers.hpp"
 #include <triqs/mesh.hpp>
 #include "utils/gf_supp.hpp"
 
@@ -15,57 +16,6 @@ namespace triqs::modest {
    initializer(omp_priv = make_block2_gf(omp_orig(0, 0).mesh(), get_struct(omp_orig)))
 #pragma omp declare reduction(block2_gf_sum : block2_gf<dlr_imfreq, matrix_valued> : omp_out += omp_in)                                              \
    initializer(omp_priv = make_block2_gf(omp_orig(0, 0).mesh(), get_struct(omp_orig)))
-
-  namespace detail {
-
-    template <typename Mesh>
-    constexpr auto upfold_self_energy_at_freq(one_body_elements_on_grid const &obe, downfolding_projector const &Proj,
-                                              block2_gf<Mesh, matrix_valued> const &Sigma_dynamic,
-                                              nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static, long w_idx, long k_idx, long sigma_idx) {
-      auto N_nu = obe.H.N_nu(sigma_idx, k_idx);
-      auto out  = nda::zeros<dcomplex>(N_nu, N_nu);
-      for (auto &&[alpha, R] : enumerated_sub_slices(get_struct(Sigma_dynamic).dims(r_all, 0) | tl::to<std::vector>())) {
-        auto P = Proj.P(sigma_idx, k_idx)(R, r_all);
-        out(r_all, r_all) +=
-           dagger(P) * nda::matrix<dcomplex>{Sigma_dynamic(alpha, sigma_idx).data()(w_idx, r_all, r_all) + Sigma_static(alpha, sigma_idx)} * P;
-      }
-      return out;
-    }
-
-    // --------------------------------------------------------------------
-    template <typename Mesh>
-    constexpr auto local_gf_at_k(one_body_elements_on_grid const &obe, double const &mu, downfolding_projector const &Proj,
-                                 block2_gf<Mesh, matrix_valued> const &Sigma_dynamic, nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
-      return [&](auto const &k_idx, auto const &sigma_idx) {
-        using nda::linalg::inv;
-        auto const n_M   = obe.C_space.dim();
-        auto const &mesh = Sigma_dynamic(0, 0).mesh();
-        auto out         = gf{mesh, {n_M, n_M}};
-        auto P           = obe.P.P(sigma_idx, k_idx);
-        for (auto &&[n, w] : enumerate(mesh)) {
-          auto PSP                    = upfold_self_energy_at_freq(obe, Proj, Sigma_dynamic, Sigma_static, n, k_idx, sigma_idx);
-          out.data()(n, r_all, r_all) = P * inv(w + mu - obe.H.H(sigma_idx, k_idx) - PSP) * dagger(P);
-        }
-        return out;
-      };
-    }
-
-    template <typename Mesh>
-    constexpr auto lattice_gf_at_k(one_body_elements_on_grid const &obe, double const &mu, block2_gf<Mesh, matrix_valued> const &Sigma_dynamic,
-                                   nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
-      return [&](auto const &k_idx, auto const &sigma_idx) {
-        using nda::linalg::inv;
-        auto const &mesh = Sigma_dynamic(0, 0).mesh();
-        auto N_nu        = obe.H.N_nu(sigma_idx, k_idx);
-        auto Glatt       = gf{mesh, {N_nu, N_nu}};
-        for (auto &&[n, w] : enumerate(mesh)) {
-          auto PSP                      = upfold_self_energy_at_freq(obe, obe.P, Sigma_dynamic, Sigma_static, n, k_idx, sigma_idx);
-          Glatt.data()(n, r_all, r_all) = inv(w + mu - obe.H.H(sigma_idx, k_idx) - PSP);
-        }
-        return Glatt;
-      };
-    }
-  } // namespace detail
 
   /** @cond DOXYGEN_SKIP_THIS */
   /**

--- a/c++/triqs_modest/h5.cpp
+++ b/c++/triqs_modest/h5.cpp
@@ -6,6 +6,7 @@
 #include <h5/h5.hpp>
 #include "downfolding.hpp"
 #include "embedding.hpp"
+#include "postprocess.hpp"
 #include <H5Tpublic.h> // HDF5 type creation API
 
 template <> h5::hid_t h5::detail::hid_t_of<triqs::modest::embedding::imp_block_t>() {
@@ -124,4 +125,34 @@ namespace triqs::modest {
     h5_write(subgroup, "P", obe.P);
     //h5_write(subgroup, "ibz_symm_ops", obe.ibz_symm_ops);
   }
+
+  // spectral function containers
+  void h5_read(h5::group g, std::string const &name, spectral_function_w &Aw) {
+    auto subgroup = g.open_group(name);
+    assert_hdf5_format(g, Aw);
+    h5_read(subgroup, "total", Aw.total);
+    h5_read(subgroup, "projected", Aw.projected);
+  }
+
+  void h5_write(h5::group g, std::string const &name, spectral_function_w const &Aw) {
+    auto subgroup = g.create_group(name);
+    write_hdf5_format(g, Aw);
+    h5_write(subgroup, "total", Aw.total);
+    h5_write(subgroup, "projected", Aw.projected);
+  }
+
+  void h5_read(h5::group g, std::string const &name, spectral_function_kw &Akw) {
+    auto subgroup = g.open_group(name);
+    assert_hdf5_format(g, Akw);
+    h5_read(subgroup, "total", Akw.total);
+    h5_read(subgroup, "projected", Akw.projected);
+  }
+
+  void h5_write(h5::group g, std::string const &name, spectral_function_kw const &Akw) {
+    auto subgroup = g.create_group(name);
+    write_hdf5_format(g, Akw);
+    h5_write(subgroup, "total", Akw.total);
+    h5_write(subgroup, "projected", Akw.projected);
+  }
+
 } // namespace triqs::modest

--- a/c++/triqs_modest/lattice_gf_helpers.hpp
+++ b/c++/triqs_modest/lattice_gf_helpers.hpp
@@ -7,6 +7,7 @@
 #include <nda/nda.hpp>
 #include <triqs/gfs.hpp>
 #include "./downfolding.hpp"
+#include "./obe_tb.hpp"
 #include "utils/defs.hpp"
 #include "utils/enumerate_slice.hpp"
 #include "utils/nda_supp.hpp"
@@ -338,6 +339,56 @@ namespace triqs::modest::detail {
       G(n, r_all, r_all) += nda::matrix<dcomplex>{Lmat * KR};
     }
     return G;
+  }
+
+  // ===================================================================================
+  // OBE-TB helpers.  The TB Hamiltonian lives in the Wannier basis already, so Σ is
+  // "upfolded" by writing its impurity blocks into the embedding rows/cols of the full
+  // n_orb × n_orb matrix (no projector multiplication).
+  // ===================================================================================
+
+  /// Index-embed Σ for ALL frequencies into the full Wannier basis, given (σ).
+  /// Returns (n_w, n_orb, n_orb).  Sibling of `upfold_self_energy_all_freq` for OBE-TB.
+  inline auto embed_self_energy_all_freq(one_body_elements_tb const &obe, auto const &Sigma_w, long sigma_idx) {
+    long n_orb = obe.H[sigma_idx].n_orbitals();
+    long n_w   = Sigma_w(0, 0).mesh().size();
+    auto out   = nda::zeros<dcomplex>(n_w, n_orb, n_orb);
+
+    auto embedding_decomp = get_struct(Sigma_w).dims(r_all, 0) | tl::to<std::vector>();
+    for (auto &&[block, R] : enumerated_sub_slices(embedding_decomp)) {
+      auto Sigma_blk = Sigma_w(block, sigma_idx).data();
+      for (auto n : range(n_w)) { out(n, R, R) += nda::matrix<dcomplex>{Sigma_blk(n, r_all, r_all)}; }
+    }
+    return out;
+  }
+
+  /// Uniform Γ-centered Monkhorst-Pack k-mesh from `opt.k_grid`, in fractional coords.
+  /// Convention k_i = i / N_i (i = 0..N_i-1), matching `integrate_ptr`.
+  /// Throws if `opt.run_adaptive` — adaptive integration is not supported for spectral
+  /// postprocessing.
+  inline nda::array<double, 2> make_uniform_k_mesh(bz_int_options const &opt) {
+    if (opt.run_adaptive) {
+      throw std::runtime_error(
+         "make_uniform_k_mesh: adaptive integration is unsupported "
+         "for spectral postprocessing — set opt.run_adaptive = false.");
+    }
+    auto Nx  = opt.k_grid[0];
+    auto Ny  = opt.k_grid[1];
+    auto Nz  = opt.k_grid[2];
+    long n_k = Nx * Ny * Nz;
+    nda::array<double, 2> k_list(n_k, 3);
+    long i = 0;
+    for (long ix = 0; ix < Nx; ++ix) {
+      for (long iy = 0; iy < Ny; ++iy) {
+        for (long iz = 0; iz < Nz; ++iz) {
+          k_list(i, 0) = double(ix) / double(Nx);
+          k_list(i, 1) = double(iy) / double(Ny);
+          k_list(i, 2) = double(iz) / double(Nz);
+          ++i;
+        }
+      }
+    }
+    return k_list;
   }
 
 } // namespace triqs::modest::detail

--- a/c++/triqs_modest/lattice_gf_helpers.hpp
+++ b/c++/triqs_modest/lattice_gf_helpers.hpp
@@ -37,6 +37,21 @@ namespace triqs::modest::detail {
   }
 
   // ===================================================================================
+  // Apply K = Σ_a · (I − Y_aa · Σ_a)⁻¹ to a right-hand side R, returning K · R.
+  // Computed without inverting Σ_a (which is singular at large iω_n / for static-only Σ).
+  //   1) Solve  (I − Y_aa · Σ_a) · X = R              [LAPACK getrf + getrs via Ainv_B]
+  //   2) K · R = Σ_a · X
+  // ===================================================================================
+  inline nda::matrix<dcomplex> apply_K(nda::matrix<dcomplex> const &Sa, nda::matrix<dcomplex> const &Yaa, nda::matrix_const_view<dcomplex> R) {
+    long rank = Sa.extent(0);
+    auto LHS  = nda::matrix<dcomplex, nda::F_layout>{-Yaa * Sa};
+    for (auto i : range(rank)) LHS(i, i) += 1.0;
+    auto X = nda::matrix<dcomplex, nda::F_layout>{R};
+    Ainv_B(LHS, X);                       // X ← (I − Yaa · Sa)⁻¹ · R
+    return nda::matrix<dcomplex>{Sa * X}; // K · R = Σ_a · X
+  }
+
+  // ===================================================================================
   // Per-(k, σ, ω) Σ upfolding and lattice GF builders — direct N_ν × N_ν inversion path.
   // Used by the matrix-valued-H fallbacks (in `gloc` and the spectral functions)
   // ===================================================================================
@@ -103,6 +118,226 @@ namespace triqs::modest::detail {
       }
       return Glatt;
     };
+  }
+
+  // ===================================================================================
+  // Rank-reduced Woodbury — for diagonal H(k) and block-sparse Σ.
+  //
+  // Σ is structurally sparse in C-space: non-zero only on a few rows × columns indexed
+  // by the active impurity blocks. The whole calculation collapses
+  // from M-dim (full C-space) to rank-dim (active rows only).
+  //
+  //     M₀(ω, ν) = (ω + iδ + μ − ε_ν(k))     [diagonal, since H_k is diagonal]
+  //     Q        = P_active[active C rows, :] (rank × N_ν)
+  //     K        = (Σ_active⁻¹ − Q M₀⁻¹ Q†)⁻¹  (rank × rank)
+  //
+  //     trace(G_k)        = trace(M₀⁻¹)            +  trace(K · Q M₀⁻² Q†)
+  //     diag(P G_k P†)_m  = diag(P M₀⁻¹ P†)_m      +  ((P M₀⁻¹ Q†) · K · (Q M₀⁻¹ P†))_{mm}
+  // ===================================================================================
+
+  /// The active subspace: which embed blocks of Σ are non-zero and where they sit in C-space.
+  struct active_subspace_t {
+    std::vector<long> alphas;     ///< α indices into Sigma_w that have non-zero data
+    std::vector<long> block_dims; ///< m_α for each active α
+    std::vector<long> c_indices;  ///< C-space row indices: ⋃ R(α) over active α
+    long rank;                    ///< = c_indices.size()
+  };
+
+  active_subspace_t detect_active_subspace(auto const &Sigma_w, std::vector<long> const &decomp, double tol = 1e-15) {
+    active_subspace_t A{};
+    long n_sigma = Sigma_w.size2();
+    long offset  = 0;
+    for (long alpha = 0; alpha < long(decomp.size()); ++alpha) {
+      long m_a     = decomp[alpha];
+      bool nonzero = false;
+      for (long s = 0; s < n_sigma && !nonzero; ++s) {
+        auto const &dat = Sigma_w(alpha, s).data();
+        for (long in = 0; in < dat.extent(0) && !nonzero; ++in)
+          for (long i = 0; i < m_a && !nonzero; ++i)
+            for (long j = 0; j < m_a && !nonzero; ++j)
+              if (std::abs(dat(in, i, j)) > tol) nonzero = true;
+      }
+      if (nonzero) {
+        A.alphas.push_back(alpha);
+        A.block_dims.push_back(m_a);
+        for (long i = 0; i < m_a; ++i) A.c_indices.push_back(offset + i);
+      }
+      offset += m_a;
+    }
+    A.rank = long(A.c_indices.size());
+    return A;
+  }
+
+  /// Bare projected propagators at fixed (k, σ), batched over ω.
+  /// `G0_PP` is the full M × M block; the diagonal is just `G0_PP(n, m, m)`.
+  struct bare_projected_t {
+    nda::array<dcomplex, 3> G0_PP;         ///< (n_ω, M, M)        = P M₀⁻¹ P†                FULL
+    nda::array<dcomplex, 3> G0_PQ;         ///< (n_ω, M, rank)     = P M₀⁻¹ Q†
+    nda::array<dcomplex, 3> G0_QPdag;      ///< (n_ω, rank, M)     = Q M₀⁻¹ P†   (≠ dagger(G0_PQ) for iδ)
+    nda::array<dcomplex, 3> G0_QQ;         ///< (n_ω, rank, rank)  = Q M₀⁻¹ Q†
+    nda::array<dcomplex, 3> G0_QQ_sq;      ///< (n_ω, rank, rank)  = Q M₀⁻² Q†
+    nda::array<dcomplex, 1> G0_band_trace; ///< (n_ω,)             = trace(M₀⁻¹) = Σ_ν M₀⁻¹(ω, ν)
+  };
+
+  /// Compute bare projected propagators using two projectors: `obe.P` (M-side / output) and
+  /// `P_active` (rank-side). When `P_active == obe.P` this matches the single-projector case;
+  /// when different it implements the two-projector kernel.
+  inline bare_projected_t compute_bare_projected(one_body_elements_on_grid const &obe, downfolding_projector const &P_active, double mu, long k_idx,
+                                                 long sigma, std::vector<dcomplex> const &omegas, active_subspace_t const &A) {
+    auto n_nu          = obe.H.N_nu(sigma, k_idx);
+    auto R_nu          = nda::range(n_nu);
+    auto M             = obe.C_space.dim();
+    auto rank          = A.rank;
+    auto n_omega       = long(omegas.size());
+    auto P_obe         = obe.P.P(sigma, k_idx);
+    auto P_act         = P_active.P(sigma, k_idx);
+    auto Hk            = obe.H.H(sigma, k_idx);
+    auto const &active = A.c_indices;
+
+    // Dinv(n, ν) = 1/(ω_n + μ − ε_ν), Dinv²(n, ν), band trace tr0(n) = Σ_ν Dinv(n, ν).
+    auto Dinv  = nda::matrix<dcomplex>(n_omega, n_nu);
+    auto Dinv2 = nda::matrix<dcomplex>(n_omega, n_nu);
+    auto tr0   = nda::vector<dcomplex>(n_omega);
+    for (auto n : range(n_omega)) {
+      dcomplex tr0_n = 0;
+      for (auto nu : R_nu) {
+        auto d       = 1.0 / (omegas[n] + mu - Hk(nu, nu));
+        Dinv(n, nu)  = d;
+        Dinv2(n, nu) = d * d;
+        tr0_n += d;
+      }
+      tr0(n) = tr0_n;
+    }
+
+    // Index tensors over band index ν:
+    //   PP(ν, m, m') = obe.P(m, ν)         · conj(obe.P(m', ν))           — full M × M
+    //   PQ(ν, m, c)  = obe.P(m, ν)         · conj(P_act(active[c], ν))
+    //   QP(ν, c, m)  = P_act(active[c], ν) · conj(obe.P(m, ν))            — ≠ PQ when D complex
+    //   QQ(ν, a, b)  = P_act(active[a], ν) · conj(P_act(active[b], ν))
+    auto PP = nda::zeros<dcomplex>(n_nu, M, M);
+    for (auto m : range(M))
+      for (auto mp : range(M))
+        for (auto nu : R_nu) PP(nu, m, mp) = P_obe(m, nu) * conj(P_obe(mp, nu));
+    auto PQ = nda::zeros<dcomplex>(n_nu, M, rank);
+    for (auto m : range(M))
+      for (auto c : range(rank))
+        for (auto nu : R_nu) PQ(nu, m, c) = P_obe(m, nu) * conj(P_act(active[c], nu));
+    auto QP = nda::zeros<dcomplex>(n_nu, rank, M);
+    for (auto c : range(rank))
+      for (auto m : range(M))
+        for (auto nu : R_nu) QP(nu, c, m) = P_act(active[c], nu) * conj(P_obe(m, nu));
+    auto QQ = nda::zeros<dcomplex>(n_nu, rank, rank);
+    for (auto a : range(rank))
+      for (auto b : range(rank))
+        for (auto nu : R_nu) QQ(nu, a, b) = P_act(active[a], nu) * conj(P_act(active[b], nu));
+
+    // Five batched gemms: each is (n_ω × n_ν) × (n_ν × …).
+    // When rank == 0 the QQ/PQ/QP arrays have a zero-extent dim and as_2d() of a
+    // 3D tensor with a zero-extent inner dim produces a grouped view with min_stride == 0,
+    // which trips nda's BLAS precondition.  Skip those gemms — callers short-circuit on rank==0.
+    auto G0_PP    = nda::zeros<dcomplex>(n_omega, M, M);
+    auto G0_PQ    = nda::zeros<dcomplex>(n_omega, M, rank);
+    auto G0_QPdag = nda::zeros<dcomplex>(n_omega, rank, M);
+    auto G0_QQ    = nda::zeros<dcomplex>(n_omega, rank, rank);
+    auto G0_QQ_sq = nda::zeros<dcomplex>(n_omega, rank, rank);
+    nda::blas::gemm(1, Dinv, as_2d(PP), 0, as_2d(G0_PP));
+    if (rank > 0) {
+      nda::blas::gemm(1, Dinv, as_2d(PQ), 0, as_2d(G0_PQ));
+      nda::blas::gemm(1, Dinv, as_2d(QP), 0, as_2d(G0_QPdag));
+      nda::blas::gemm(1, Dinv, as_2d(QQ), 0, as_2d(G0_QQ));
+      nda::blas::gemm(1, Dinv2, as_2d(QQ), 0, as_2d(G0_QQ_sq));
+    }
+
+    return {.G0_PP         = std::move(G0_PP),
+            .G0_PQ         = std::move(G0_PQ),
+            .G0_QPdag      = std::move(G0_QPdag),
+            .G0_QQ         = std::move(G0_QQ),
+            .G0_QQ_sq      = std::move(G0_QQ_sq),
+            .G0_band_trace = std::move(tr0)};
+  }
+
+  /// Σ_active at every ω, packed as a dense (n_ω, rank, rank) tensor with block-diagonal structure.
+  /// Independent of k: built once per σ, sliced inside the inner ω loop.
+  ///
+  /// NOTE: we use Σ_active *directly* (not its inverse) so the downstream kernel can solve
+  /// `(I − Y_aa Σ_active) X = Σ_active · …` instead of `(Σ_active⁻¹ − Y_aa) K = …`.  This avoids
+  /// inverting Σ.
+  nda::array<dcomplex, 3> compute_sigma_active(auto const &Sigma_w, active_subspace_t const &A, long sigma) {
+    long n_w = Sigma_w(0, 0).mesh().size();
+    auto out = nda::zeros<dcomplex>(n_w, A.rank, A.rank);
+    for (long n = 0; n < n_w; ++n) {
+      long off = 0;
+      for (long bi = 0; bi < long(A.alphas.size()); ++bi) {
+        long m_a     = A.block_dims[bi];
+        auto R       = nda::range(off, off + m_a);
+        out(n, R, R) = Sigma_w(A.alphas[bi], sigma).data()(n, r_all, r_all);
+        off += m_a;
+      }
+    }
+    return out;
+  }
+
+  /// μ-independent Woodbury inputs derived from Σ.
+  struct woodbury_setup {
+    std::vector<dcomplex> omegas;
+    active_subspace_t active;
+    std::vector<nda::array<dcomplex, 3>> Sa_per_sigma; ///< Σ_active(ω) per σ: (n_ω, rank, rank)
+  };
+
+  template <typename Mesh>
+  woodbury_setup make_woodbury_setup(block2_gf<Mesh, matrix_valued> const &Sigma_dynamic, nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
+    auto Sigma_total = make_sigma_total(Sigma_dynamic, Sigma_static);
+    auto const &mesh = Sigma_total(0, 0).mesh();
+    auto decomp      = get_struct(Sigma_total).dims(r_all, 0) | tl::to<std::vector>();
+    auto active      = detect_active_subspace(Sigma_total, decomp);
+    return {.omegas       = mesh | tl::to<std::vector<dcomplex>>(),
+            .active       = active,
+            .Sa_per_sigma = range(Sigma_total.size2()) | stdv::transform([&](long s) { return compute_sigma_active(Sigma_total, active, s); })
+               | tl::to<std::vector>()};
+  }
+
+  // Build the full band-basis Green's function G(ω) = [ω + iδ + μ − H(k) − P†Σ(ω)P]⁻¹ for a fixed (k, σ),
+  // returned as (n_ω, N_ν, N_ν), via the rank-reduced Woodbury identity for a diagonal band-basis H(k).
+  inline nda::array<dcomplex, 3> build_G_band(one_body_elements_on_grid const &obe, active_subspace_t const &active,
+                                              nda::array<dcomplex, 3> const &Sa_n, std::vector<dcomplex> const &omegas, double mu, long k_idx,
+                                              long sigma) {
+    long N_nu = obe.H.N_nu(sigma, k_idx);
+    long n_w  = long(omegas.size());
+    auto Hk   = obe.H.H(sigma, k_idx);
+    auto G    = nda::zeros<dcomplex>(n_w, N_nu, N_nu);
+
+    // Diagonal H(k): rank-reduced Woodbury.  G = D⁻¹ + D⁻¹Q† K Q D⁻¹,
+    //   D(ν) = ω + iδ + μ − ε_ν,   Q = active rows of P (rank × N_ν),
+    //   K = (Σ_a⁻¹ − Q D⁻¹ Q†)⁻¹  applied via apply_K (no inversion of Σ).
+    long rank = active.rank;
+    auto P    = obe.P.P(sigma, k_idx); // (M × N_ν)
+    auto Q    = nda::matrix<dcomplex>(rank, N_nu);
+    for (auto c : range(rank))
+      for (auto nu : range(N_nu)) Q(c, nu) = P(active.c_indices[c], nu);
+
+    for (auto n : range(n_w)) {
+      auto Dinv = nda::vector<dcomplex>(N_nu);
+      for (auto nu : range(N_nu)) {
+        Dinv(nu)     = 1.0 / (omegas[n] + mu - Hk(nu, nu));
+        G(n, nu, nu) = Dinv(nu);
+      }
+      if (rank == 0) continue;
+
+      // Rmat = Q · D⁻¹  (rank × N_ν);   Yaa = Q D⁻¹ Q† = Rmat · Q†
+      auto Rmat = nda::matrix<dcomplex>(rank, N_nu);
+      for (auto c : range(rank))
+        for (auto nu : range(N_nu)) Rmat(c, nu) = Q(c, nu) * Dinv(nu);
+      auto Yaa = nda::matrix<dcomplex>{Rmat * dagger(Q)};
+      auto Sa  = nda::matrix<dcomplex>{Sa_n(n, r_all, r_all)};
+      auto KR  = apply_K(Sa, Yaa, Rmat); // K · (Q D⁻¹): (rank × N_ν)
+
+      // Lmat = D⁻¹ Q†  (N_ν × rank);   correction = Lmat · KR  (≠ Rmat† for complex D).
+      auto Lmat = nda::matrix<dcomplex>(N_nu, rank);
+      for (auto nu : range(N_nu))
+        for (auto c : range(rank)) Lmat(nu, c) = Dinv(nu) * conj(Q(c, nu));
+      G(n, r_all, r_all) += nda::matrix<dcomplex>{Lmat * KR};
+    }
+    return G;
   }
 
 } // namespace triqs::modest::detail

--- a/c++/triqs_modest/lattice_gf_helpers.hpp
+++ b/c++/triqs_modest/lattice_gf_helpers.hpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2025--present, The Simons Foundation
+// This file is part of TRIQS/modest and is licensed under the terms of GPLv3 or later.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// See LICENSE in the root of this distribution for details.
+
+#pragma once
+#include <nda/nda.hpp>
+#include <triqs/gfs.hpp>
+#include "./downfolding.hpp"
+#include "utils/defs.hpp"
+#include "utils/enumerate_slice.hpp"
+#include "utils/nda_supp.hpp"
+
+namespace triqs::modest::detail {
+
+  // ===================================================================================
+  // View an (n_ω, A, B) tensor as a 2D matrix (n_ω × A·B) for batched gemm.
+  // ===================================================================================
+  template <typename T> auto as_2d(T &&t) { return cmat_vt{nda::group_indices_view(std::forward<T>(t), nda::idx_group<0>, nda::idx_group<1, 2>)}; }
+
+  // ===================================================================================
+  // Σ_total(α, σ)(ω) = Σ_dynamic(α, σ)(ω) + Σ_static(α, σ).
+  // ===================================================================================
+  template <typename Mesh>
+  block2_gf<Mesh, matrix_valued> make_sigma_total(block2_gf<Mesh, matrix_valued> const &Sigma_dynamic,
+                                                  nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
+    auto Sigma_total = make_block2_gf(Sigma_dynamic(0, 0).mesh(), get_struct(Sigma_dynamic));
+    for (auto alpha : range(Sigma_dynamic.size1())) {
+      for (auto sigma : range(Sigma_dynamic.size2())) {
+        auto const &Sstat = Sigma_static(alpha, sigma);
+        long n_w          = Sigma_dynamic(alpha, sigma).data().extent(0);
+        for (long n = 0; n < n_w; ++n)
+          Sigma_total(alpha, sigma).data()(n, r_all, r_all) = Sigma_dynamic(alpha, sigma).data()(n, r_all, r_all) + Sstat;
+      }
+    }
+    return Sigma_total;
+  }
+
+  // ===================================================================================
+  // Per-(k, σ, ω) Σ upfolding and lattice GF builders — direct N_ν × N_ν inversion path.
+  // Used by the matrix-valued-H fallbacks (in `gloc` and the spectral functions)
+  // ===================================================================================
+
+  /// Upfold Σ at a single frequency w_idx: returns N_ν × N_ν.
+  constexpr auto upfold_self_energy_at_freq(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, auto const &Sigma_dynamic,
+                                            nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static, long w_idx, long k_idx, long sigma_idx) {
+    auto N_nu = obe.H.N_nu(sigma_idx, k_idx);
+    auto out  = nda::zeros<dcomplex>(N_nu, N_nu);
+    for (auto &&[alpha, R] : enumerated_sub_slices(get_struct(Sigma_dynamic).dims(r_all, 0) | tl::to<std::vector>())) {
+      auto P = Proj.P(sigma_idx, k_idx)(R, r_all);
+      out(r_all, r_all) +=
+         dagger(P) * nda::matrix<dcomplex>{Sigma_dynamic(alpha, sigma_idx).data()(w_idx, r_all, r_all) + Sigma_static(alpha, sigma_idx)} * P;
+    }
+    return out;
+  }
+
+  /// Upfold Σ for ALL frequencies at once for a given (k, σ).  Returns (n_w, N_ν, N_ν).
+  /// Used by the matrix-valued-H fallback paths that need PSP at every ω in one go.
+  /// (`Sigma_static` is assumed zero here — postprocess's refreq fallbacks don't carry one.)
+  inline auto upfold_self_energy_all_freq(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, auto const &Sigma_w, long k_idx,
+                                          long sigma_idx) {
+    auto N_nu = obe.H.N_nu(sigma_idx, k_idx);
+    auto n_w  = Sigma_w(0, 0).mesh().size();
+    auto out  = nda::zeros<dcomplex>(n_w, N_nu, N_nu);
+
+    for (auto &&[alpha, R] : enumerated_sub_slices(get_struct(Sigma_w).dims(r_all, 0) | tl::to<std::vector>())) {
+      auto P         = Proj.P(sigma_idx, k_idx)(R, r_all);
+      auto Pdag      = dagger(P);
+      auto Sigma_blk = Sigma_w(alpha, sigma_idx).data();
+
+      // Batch over all frequencies
+      for (auto n : range(n_w)) { out(n, r_all, r_all) += Pdag * nda::matrix<dcomplex>{Sigma_blk(n, r_all, r_all)} * P; }
+    }
+    return out;
+  }
+
+  constexpr auto local_gf_at_k(one_body_elements_on_grid const &obe, double const &mu, downfolding_projector const &Proj, auto const &Sigma_dynamic,
+                               nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
+    return [&](auto const &k_idx, auto const &sigma_idx) {
+      using nda::linalg::inv;
+      auto const n_M   = obe.C_space.dim();
+      auto const &mesh = Sigma_dynamic(0, 0).mesh();
+      auto out         = gf{mesh, {n_M, n_M}};
+      auto P           = obe.P.P(sigma_idx, k_idx);
+      for (auto &&[n, w] : enumerate(mesh)) {
+        auto PSP                    = upfold_self_energy_at_freq(obe, Proj, Sigma_dynamic, Sigma_static, n, k_idx, sigma_idx);
+        out.data()(n, r_all, r_all) = P * inv(w + mu - obe.H.H(sigma_idx, k_idx) - PSP) * dagger(P);
+      }
+      return out;
+    };
+  }
+
+  constexpr auto lattice_gf_at_k(one_body_elements_on_grid const &obe, double const &mu, auto const &Sigma_dynamic,
+                                 nda::array<nda::matrix<dcomplex>, 2> const &Sigma_static) {
+    return [&](auto const &k_idx, auto const &sigma_idx) {
+      using nda::linalg::inv;
+      auto const &mesh = Sigma_dynamic(0, 0).mesh();
+      auto N_nu        = obe.H.N_nu(sigma_idx, k_idx);
+      auto Glatt       = gf{mesh, {N_nu, N_nu}};
+      for (auto &&[n, w] : enumerate(mesh)) {
+        auto PSP                      = upfold_self_energy_at_freq(obe, obe.P, Sigma_dynamic, Sigma_static, n, k_idx, sigma_idx);
+        Glatt.data()(n, r_all, r_all) = inv(w + mu - obe.H.H(sigma_idx, k_idx) - PSP);
+      }
+      return Glatt;
+    };
+  }
+
+} // namespace triqs::modest::detail

--- a/c++/triqs_modest/loaders.cpp
+++ b/c++/triqs_modest/loaders.cpp
@@ -71,9 +71,9 @@ namespace triqs::modest {
   //-------------------------------------------------------
   // Enumerate the different reading modes for the obe factory functions.
   enum class ReadMode {
-    Correlated,      // reads bands, projectors, and correlated shells from "dft_input"
-    ThetaProjectors, // read bands ands shells from "dft_input" and projectors from "dft_parproj_input" ("proj_mat_all")
-    Bands            // read bands and projectors from "dft_bands_input"
+    Correlated,        // reads bands, projectors, and correlated shells from "dft_input"
+    PartialProjectors, // read bands ands shells from "dft_input" and projectors from "dft_parproj_input" ("proj_mat_all")
+    Bands              // read bands and projectors from "dft_bands_input"
   };
 
   //-------------------------------------------------------
@@ -101,9 +101,9 @@ namespace triqs::modest {
              })
          | tl::to<std::vector<cmat_t>>();
     };
-    return (mode == ReadMode::Correlated)  ? read_mats(root["dft_input"], "rot_mat", "rot_mat_time_inv") :
-       (mode == ReadMode::ThetaProjectors) ? read_mats(root["dft_parproj_input"], "rot_mat_all", "rot_mat_all_time_inv") :
-                                             throw std::runtime_error("This should not happen!");
+    return (mode == ReadMode::Correlated)    ? read_mats(root["dft_input"], "rot_mat", "rot_mat_time_inv") :
+       (mode == ReadMode::PartialProjectors) ? read_mats(root["dft_parproj_input"], "rot_mat_all", "rot_mat_all_time_inv") :
+                                               throw std::runtime_error("This should not happen!");
   }
 
   //-------------------------------------------------------
@@ -115,9 +115,9 @@ namespace triqs::modest {
       if (m == ReadMode::Correlated || m == ReadMode::Bands) {
         return (m == ReadMode::Correlated) ? as<nda::array<dcomplex, 5>>(root["dft_input"]["proj_mat"]) :
                                              as<nda::array<dcomplex, 5>>(root["dft_bands_input"]["proj_mat"]);
-      } else if (m == ReadMode::ThetaProjectors) {
+      } else if (m == ReadMode::PartialProjectors) {
         auto tmp = as<nda::array<dcomplex, 6>>(root["dft_parproj_input"]["proj_mat_all"]);
-        // FIXME: The θ projectors have an extra dimesion called ir. Not sure why it is there...
+        // FIXME: The partial projectors have an extra dimesion called ir. Not sure why it is there...
         return nda::array<dcomplex, 5>{tmp(r_all, r_all, r_all, 0, r_all, r_all)};
       } else {
         throw std::runtime_error{"This should not happen!"};
@@ -151,7 +151,7 @@ namespace triqs::modest {
   // Read band dispersion and k-weights according to ReadMode. (internal)
   std::tuple<nda::array<dcomplex, 4>, nda::matrix<long>, nda::array<double, 1>> read_bands_and_weights(std::string filename, ReadMode mode) {
     auto root = h5::proxy{filename, 'r'};
-    if (mode == ReadMode::Correlated || mode == ReadMode::ThetaProjectors) {
+    if (mode == ReadMode::Correlated || mode == ReadMode::PartialProjectors) {
       auto g_dft = root["dft_input"];
       return {as<nda::array<dcomplex, 4>>(g_dft["hopping"]), as<nda::matrix<long>>(g_dft["n_orbitals"]),
               as<nda::array<double, 1>>(g_dft["bz_weights"])};
@@ -355,7 +355,7 @@ namespace triqs::modest {
     return {target_density, std::move(obe_final)};
   }
 
-  one_body_elements_on_grid read_theta_projectors_for_obe(const std::string &filename, const one_body_elements_on_grid &obe) {
+  one_body_elements_on_grid read_partial_projectors_for_obe(const std::string &filename, const one_body_elements_on_grid &obe) {
     //check for group and throw error
     auto h5root = h5::proxy{filename, 'r'};
     if (!h5root.has_group("dft_parproj_input")) {
@@ -363,7 +363,7 @@ namespace triqs::modest {
     }
 
     // all the atomic shells
-    auto atomic_shells = read_atomic_shells(filename, ReadMode::ThetaProjectors);
+    auto atomic_shells = read_atomic_shells(filename, ReadMode::PartialProjectors);
 
     // The decomposition and rotations must be embedded from the C spcae to the W space
     auto new_block_decomposition = detail::inject_to_new_space(obe.C_space.atoms_block_decomposition(), obe.C_space.atomic_shells(), atomic_shells);
@@ -371,29 +371,29 @@ namespace triqs::modest {
     // The local space expanded from C to W
     auto W_space = local_space{obe.C_space.spin_kind(), atomic_shells, new_block_decomposition, {}, {}};
 
-    // rotation matrices using ThetaProjector mode
-    auto rot_mats = read_rotation_matrices(filename, ReadMode::ThetaProjectors);
+    // rotation matrices using PartialProjectors mode
+    auto rot_mats = read_rotation_matrices(filename, ReadMode::PartialProjectors);
 
     // read and rotate projectors
-    auto atom_decomp = W_space.atomic_decomposition() | tl::to<std::vector<long>>();
-    auto P_k         = load_rotate_and_format_projectors(filename, ReadMode::ThetaProjectors, rot_mats, atom_decomp);
-    auto theta_proj  = downfolding_projector{.spin_kind = obe.C_space.spin_kind(), .P_k = std::move(P_k), .n_bands_per_k = obe.H.n_bands_per_k};
+    auto atom_decomp  = W_space.atomic_decomposition() | tl::to<std::vector<long>>();
+    auto P_k          = load_rotate_and_format_projectors(filename, ReadMode::PartialProjectors, rot_mats, atom_decomp);
+    auto partial_proj = downfolding_projector{.spin_kind = obe.C_space.spin_kind(), .P_k = std::move(P_k), .n_bands_per_k = obe.H.n_bands_per_k};
 
     // create a new IBZ symmetrizer that spans all atoms instead of just the correlated atoms
-    auto symm_ops = (obe.ibz_symm_ops) ? std::optional<ibz_symmetry_ops>(read_ibz_symmetry_ops(filename, ReadMode::ThetaProjectors)) :
+    auto symm_ops = (obe.ibz_symm_ops) ? std::optional<ibz_symmetry_ops>(read_ibz_symmetry_ops(filename, ReadMode::PartialProjectors)) :
                                          std::optional<ibz_symmetry_ops>{};
-    return one_body_elements_on_grid{.H = obe.H, .C_space = W_space, .P = theta_proj, .ibz_symm_ops = symm_ops};
+    return one_body_elements_on_grid{.H = obe.H, .C_space = W_space, .P = partial_proj, .ibz_symm_ops = symm_ops};
   }
 
   //-------------------------------------------------------
-  // Prepare one-body elements with the Θ projectors.
-  one_body_elements_on_grid one_body_elements_with_theta_projectors(std::string const &filename, one_body_elements_on_grid const &obe) {
+  // Prepare one-body elements with the partial projectors.
+  one_body_elements_on_grid one_body_elements_with_partial_projectors(std::string const &filename, one_body_elements_on_grid const &obe) {
 
     mpi::communicator comm = {};
     int root               = 0;
     one_body_elements_on_grid obe_final;
 
-    if (comm.rank() == root) { obe_final = read_theta_projectors_for_obe(filename, obe); }
+    if (comm.rank() == root) { obe_final = read_partial_projectors_for_obe(filename, obe); }
 
     mpi::broadcast(obe_final, comm, root);
     return obe_final;

--- a/c++/triqs_modest/loaders.hpp
+++ b/c++/triqs_modest/loaders.hpp
@@ -17,7 +17,7 @@ namespace triqs::modest {
   C2PY_IGNORE std::pair<double, one_body_elements_on_grid> read_obe_from_dft_converter_hdf5(std::string const &filename, double threshold = 1.e-5,
                                                                                             bool diagonalize_hloc = false);
 
-  C2PY_IGNORE one_body_elements_on_grid read_theta_projectors_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
+  C2PY_IGNORE one_body_elements_on_grid read_partial_projectors_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
 
   C2PY_IGNORE one_body_elements_on_grid read_data_on_high_symm_path_for_obe(std::string const &filename, one_body_elements_on_grid const &obe);
 
@@ -68,7 +68,7 @@ namespace triqs::modest {
 
   /**
    * @ingroup one_body_elements
-   * @brief Create a one-body elements with the \f$ \Theta \f$ projectors.
+   * @brief Create a one-body elements with partial (all-atom) projectors.
    *
    * @details Using the data from the "dft_parproj_input" group, the local space, downfolding projectors,
    * and optional IBZ symmetry ops are prepared to create a one-body elements. This object is
@@ -76,9 +76,9 @@ namespace triqs::modest {
    *
    * @param filename Hdf5 file from DFTtools converter with "dft_parproj_input" group.
    * @param obe One-body elements that was used in the DMFT calculation.
-   * @return One-body elements using the \f$ \Theta \f$ projectors.
+   * @return One-body elements using the partial projectors.
    */
-  one_body_elements_on_grid one_body_elements_with_theta_projectors(std::string const &filename, one_body_elements_on_grid const &obe);
+  one_body_elements_on_grid one_body_elements_with_partial_projectors(std::string const &filename, one_body_elements_on_grid const &obe);
 
   /**
    * @ingroup one_body_elements

--- a/c++/triqs_modest/obe_tb.cpp
+++ b/c++/triqs_modest/obe_tb.cpp
@@ -59,7 +59,7 @@ namespace triqs::modest {
      : H{std::move(H_sigma)} {
 
     // check that appropriate Hamiltonian information was provided
-    if (H[0].n_orbitals() != H[1].n_orbitals()) {
+    if (spin_kind != spin_kind_e::NonColinear && H[0].n_orbitals() != H[1].n_orbitals()) {
       throw std::runtime_error(
          "Cannot construct a one_body_elements "
          "using up and down H_k that have a different number of orbitals.");
@@ -153,7 +153,7 @@ namespace triqs::modest {
       }
     }
 
-    return one_body_elements_tb(std::move(new_H), obe.C_space);
+    return {std::move(new_H), obe.C_space};
   }
 
   // -----------------------------------------------------------------------
@@ -179,16 +179,17 @@ namespace triqs::modest {
       return ext_mat;
     };
 
-    std::vector<nda::array<dcomplex, 2>> new_hoppings;
-    for (auto const &tR : obe.H[0].hoppings()) new_hoppings.emplace_back(extend_matrix(tR));
-    auto new_tb_H = std::vector<tb_hk>{{Rs, std::move(new_hoppings)}};
+    std::vector<nda::array<dcomplex, 2>> ext_hoppings;
+    for (auto const &tR : obe.H[0].hoppings()) ext_hoppings.emplace_back(extend_matrix(tR));
+    std::vector<tb_hk> ext_tb_H;
+    ext_tb_H.emplace_back(Rs, std::move(ext_hoppings));
 
     auto const &sh         = obe.C_space.atomic_shells();
     auto new_atomic_shells = sh
        | stdv::transform([](auto const &s) { return atomic_orbs{.dim = 2 * s.dim, .l = s.l, .cls_idx = s.cls_idx, .dft_idx = s.dft_idx}; })
        | tl::to<std::vector>();
 
-    return one_body_elements_tb(std::move(new_tb_H), spin_kind_e::NonColinear, std::move(new_atomic_shells));
+    return {std::move(ext_tb_H), spin_kind_e::NonColinear, std::move(new_atomic_shells)};
   }
 
   // -----------------------------------------------------------------------

--- a/c++/triqs_modest/obe_tb.hpp
+++ b/c++/triqs_modest/obe_tb.hpp
@@ -61,6 +61,7 @@ namespace triqs::modest {
       mpi::broadcast(x.C_space, c, root);
       mpi::broadcast(x.H, c, root);
     }
+    friend std::ostream &operator<<(std::ostream &out, one_body_elements_tb const &x);
   };
 
   /** @name OBE factories using a TB Hamiltonian

--- a/c++/triqs_modest/postprocess.cpp
+++ b/c++/triqs_modest/postprocess.cpp
@@ -11,18 +11,13 @@
 
 namespace triqs::modest {
 
-  // All `detail::` helpers used here (upfold_self_energy_all_freq, detect_active_subspace,
-  // compute_bare_projected, compute_sigma_active, apply_K, …) live in `lattice_gf_helpers.hpp`.
-
-  // Single-projector overload — delegates to the two-projector implementation with Proj = obe.P.
+  // Single-projector overload
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
     return projected_spectral_function(obe, obe.P, mu, Sigma_w, broadening);
   }
 
-  // Two-projector overload — the canonical implementation. Used directly for cases where Σ is
-  // upfolded by a `Proj` distinct from `obe.P`; the single-projector overload above just calls
-  // through with Proj = obe.P.
+  // Two-projector overload — the canonical implementation.
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
     auto const &mesh = Sigma_w(0, 0).mesh();
@@ -81,7 +76,7 @@ namespace triqs::modest {
           auto w_k         = obe.H.k_weights(k_idx);
           auto const &Sa_n = Sa_per_sigma[sigma];
 
-          // Σ ≡ 0 short-circuit: G_loc^C = G0_PP, no correction. Avoids the 0 × 0 K-solve.
+          // Σ ≡ 0 short-circuit: G_loc^C = G0_PP, no correction.
           if (rank == 0) {
             for (long n = 0; n < n_w; ++n) gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * bare.G0_PP(n, r_all, r_all);
             continue;
@@ -136,9 +131,6 @@ namespace triqs::modest {
     auto total     = nda::zeros<double>(n_sigma, n_k, n_w);
     auto projected = nda::zeros<double>(n_sigma, n_k, n_w, n_M);
 
-    // Each k-point's outputs land in independent slots of (total, projected).  Each MPI rank fills
-    // only its own k-chunk and leaves the other slots zero, so all_reduce(+) acts as a gather —
-    // not a sum over k in the mathematical sense.
     mpi::communicator comm = {};
 
     // Matrix-valued H(k): direct N_ν × N_ν inversion.
@@ -226,6 +218,132 @@ namespace triqs::modest {
     auto t_end        = std::chrono::steady_clock::now();
     double total_secs = std::chrono::duration<double>(t_end - t_start).count();
     if (comm.rank() == 0) std::cerr << "spectral_function_on_high_symmetry_path: total " << total_secs << " s\n";
+    total     = mpi::all_reduce(total);
+    projected = mpi::all_reduce(projected);
+    return {.total = total, .projected = projected};
+  }
+
+  //-------------------------------------------------------------------------------------------
+  // OBE tight-binding implementations
+  //-------------------------------------------------------------------------------------------
+
+  spectral_function_w projected_spectral_function(one_body_elements_tb const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
+                                                  bz_int_options const &opt, double broadening) {
+    using nda::linalg::inv;
+
+    auto const &mesh = Sigma_w(0, 0).mesh();
+    long n_sigma     = obe.C_space.n_sigma();
+    long n_M         = obe.C_space.dim();
+    long n_w         = mesh.size();
+    auto im          = dcomplex(0, 1.0);
+    auto delta       = im * broadening;
+    auto R_C         = nda::range(0, n_M);
+
+    auto k_list     = detail::make_uniform_k_mesh(opt);
+    long n_k        = k_list.extent(0);
+    double k_weight = 1.0 / double(n_k);
+
+    mpi::communicator comm = {};
+
+    auto my_indices = mpi::chunk(range(n_k), comm) | tl::to<std::vector<long>>();
+    long my_n_k     = long(my_indices.size());
+    nda::array<double, 2> my_k_list(my_n_k, 3);
+    for (long i = 0; i < my_n_k; ++i) {
+      long k_idx = my_indices[i];
+      for (long d = 0; d < 3; ++d) my_k_list(i, d) = k_list(k_idx, d);
+    }
+
+    if (comm.rank() == 0)
+      std::cerr << "projected_spectral_function: starting  (n_k=" << n_k << " n_sigma=" << n_sigma //
+                << " n_w=" << n_w << " M=" << n_M << ")\n";
+    auto t_start = std::chrono::steady_clock::now();
+
+    auto gloc_result = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
+
+    for (auto sigma : range(n_sigma)) {
+      auto Sigma_emb  = detail::embed_self_energy_all_freq(obe, Sigma_w, sigma);
+      auto H_all_my_k = obe.H[sigma](nda::array_const_view<double, 2>(my_k_list)); // [my_n_k, n_orb, n_orb]
+
+      for (long i = 0; i < my_n_k; ++i) {
+        nda::matrix<dcomplex> H_k = H_all_my_k(i, r_all, r_all);
+        for (auto &&[n, w] : enumerate(mesh)) {
+          auto G_k = nda::matrix<dcomplex>{inv(w + delta + mu - H_k - nda::matrix<dcomplex>{Sigma_emb(n, r_all, r_all)})};
+          gloc_result(0, sigma).data()(n, r_all, r_all) += k_weight * G_k(R_C, R_C);
+        }
+      }
+    }
+
+    // Combine per-rank partial sums.
+    gloc_result = mpi::all_reduce(gloc_result);
+
+    auto t_end  = std::chrono::steady_clock::now();
+    double secs = std::chrono::duration<double>(t_end - t_start).count();
+    if (comm.rank() == 0) std::cerr << "projected_spectral_function: total " << secs << " s\n";
+
+    // Extract spectral functions from the local Green's function.
+    auto total     = nda::zeros<double>(n_sigma, n_w);
+    auto projected = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
+    for (auto sigma : range(n_sigma)) {
+      auto const &G = gloc_result(0, sigma).data();
+      for (auto &&[n, w] : enumerate(mesh)) {
+        auto g                            = nda::matrix<dcomplex>{G(n, r_all, r_all)};
+        total(sigma, n)                   = (-1.0 / M_PI) * imag(trace(g));
+        projected(sigma, n, r_all, r_all) = real(im * (g - dagger(g)) / (2 * M_PI));
+      }
+    }
+    return {.total = total, .projected = projected};
+  }
+
+  spectral_function_kw spectral_function_on_high_symmetry_path(one_body_elements_tb const &obe, nda::array<double, 2> const &k_list, double mu,
+                                                               block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
+    using nda::linalg::inv;
+
+    auto const &mesh = Sigma_w(0, 0).mesh();
+    auto mesh_vec    = mesh | tl::to<std::vector>();
+    long n_sigma     = obe.C_space.n_sigma();
+    long n_k         = k_list.extent(0);
+    long n_w         = mesh.size();
+    long n_M         = obe.C_space.dim();
+    auto delta       = dcomplex(0, broadening);
+
+    auto total     = nda::zeros<double>(n_sigma, n_k, n_w);
+    auto projected = nda::zeros<double>(n_sigma, n_k, n_w, n_M);
+
+    mpi::communicator comm = {};
+
+    // Batch-evaluate H(k) for the full k-list once per σ (BLAS-3 gemm); each rank then
+    // iterates its own k-chunk and writes into the corresponding slots of (total, projected).
+    std::vector<nda::array<dcomplex, 3>> Sigma_emb_per_sigma;
+    Sigma_emb_per_sigma.reserve(n_sigma);
+    for (auto sigma : range(n_sigma)) Sigma_emb_per_sigma.push_back(detail::embed_self_energy_all_freq(obe, Sigma_w, sigma));
+
+    std::vector<nda::array<dcomplex, 3>> H_per_sigma;
+    H_per_sigma.reserve(n_sigma);
+    for (auto sigma : range(n_sigma)) H_per_sigma.push_back(obe.H[sigma](nda::array_const_view<double, 2>(k_list)));
+
+    if (comm.rank() == 0)
+      std::cerr << "spectral_function_on_high_symmetry_path: starting  (n_k=" << n_k << " n_sigma=" << n_sigma //
+                << " n_w=" << n_w << " M=" << n_M << ")\n";
+    auto t_start = std::chrono::steady_clock::now();
+
+#pragma omp parallel for collapse(2) default(none)                                                                                                   \
+   shared(comm, n_k, n_sigma, n_M, H_per_sigma, Sigma_emb_per_sigma, mu, delta, mesh_vec, total, projected, r_all)
+    for (auto k_idx : mpi::chunk(range(n_k), comm)) {
+      for (auto sigma : range(n_sigma)) {
+        nda::matrix<dcomplex> H_k = H_per_sigma[sigma](k_idx, r_all, r_all);
+        auto const &Sigma_emb     = Sigma_emb_per_sigma[sigma];
+        for (auto &&[n, w] : enumerate(mesh_vec)) {
+          auto G_k               = inv(w + delta + mu - H_k - nda::matrix<dcomplex>{Sigma_emb(n, r_all, r_all)});
+          total(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
+          for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = (-1.0 / M_PI) * imag(G_k(m, m));
+        }
+      }
+    }
+
+    auto t_end  = std::chrono::steady_clock::now();
+    double secs = std::chrono::duration<double>(t_end - t_start).count();
+    if (comm.rank() == 0) std::cerr << "spectral_function_on_high_symmetry_path: total " << secs << " s\n";
+
     total     = mpi::all_reduce(total);
     projected = mpi::all_reduce(projected);
     return {.total = total, .projected = projected};

--- a/c++/triqs_modest/postprocess.cpp
+++ b/c++/triqs_modest/postprocess.cpp
@@ -33,30 +33,30 @@ namespace triqs::modest {
 
   } // namespace detail
 
-  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe_theta, downfolding_projector const &Proj, double mu,
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
     using nda::linalg::inv;
 
     auto const &mesh = Sigma_w(0, 0).mesh();
-    auto n_sigma     = obe_theta.C_space.n_sigma();
-    auto n_k         = obe_theta.H.n_k();
-    auto n_M         = obe_theta.C_space.dim();
+    auto n_sigma     = obe.C_space.n_sigma();
+    auto n_k         = obe.H.n_k();
+    auto n_M         = obe.C_space.dim();
     auto n_w         = mesh.size();
     auto im          = dcomplex(0, 1.0);
     auto delta       = im * broadening;
 
     // Accumulate local Green's function over k-points
-    auto gloc_result = make_block2_gf(mesh, obe_theta.C_space.Gc_block_shape());
+    auto gloc_result = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
 
     for (auto k_idx : range(n_k)) {
       for (auto sigma : range(n_sigma)) {
-        auto P    = obe_theta.P.P(sigma, k_idx);
+        auto P    = obe.P.P(sigma, k_idx);
         auto Pdag = dagger(P);
-        auto H_k  = obe_theta.H.H(sigma, k_idx);
-        auto w_k  = obe_theta.H.k_weights(k_idx);
+        auto H_k  = obe.H.H(sigma, k_idx);
+        auto w_k  = obe.H.k_weights(k_idx);
 
         // Precompute upfolded self-energy for all frequencies
-        auto PSP_all = detail::upfold_self_energy_all_freq(obe_theta, Proj, Sigma_w, k_idx, sigma);
+        auto PSP_all = detail::upfold_self_energy_all_freq(obe, Proj, Sigma_w, k_idx, sigma);
 
         for (auto &&[n, w] : enumerate(mesh)) {
           auto G_k = nda::matrix<dcomplex>{inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all))};
@@ -65,22 +65,22 @@ namespace triqs::modest {
       }
     }
 
-    if (auto const &S = obe_theta.ibz_symm_ops; S) { gloc_result = S->symmetrize(gloc_result, obe_theta.C_space.atomic_decomposition()); }
+    if (auto const &S = obe.ibz_symm_ops; S) { gloc_result = S->symmetrize(gloc_result, obe.C_space.atomic_decomposition()); }
 
     // Extract spectral functions from local Green's function
     auto total     = nda::zeros<double>(n_sigma, n_w);
-    auto per_theta = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
+    auto projected = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
 
     for (auto sigma : range(n_sigma)) {
       auto const &G = gloc_result(0, sigma).data();
       for (auto &&[n, w] : enumerate(mesh)) {
         auto g                            = nda::matrix<dcomplex>{G(n, r_all, r_all)};
         total(sigma, n)                   = (-1.0 / M_PI) * imag(trace(g));
-        per_theta(sigma, n, r_all, r_all) = real(im * (g - dagger(g)) / (2 * M_PI));
+        projected(sigma, n, r_all, r_all) = real(im * (g - dagger(g)) / (2 * M_PI));
       }
     }
 
-    return {.total = total, .per_theta = per_theta};
+    return {.total = total, .projected = projected};
   }
 
   nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
@@ -125,10 +125,10 @@ namespace triqs::modest {
     auto n_M         = obe.C_space.dim();
     auto delta       = dcomplex(0, broadening);
 
-    auto data      = nda::zeros<double>(n_sigma, n_k, n_w);
-    auto proj_data = nda::zeros<double>(n_sigma, n_k, n_w, n_M, n_M);
+    auto total     = nda::zeros<double>(n_sigma, n_k, n_w);
+    auto projected = nda::zeros<double>(n_sigma, n_k, n_w, n_M);
 
-#pragma omp parallel for default(none) shared(n_k, n_sigma, n_w, obe, mu, delta, Sigma_w, broadening, mesh, data, proj_data, r_all)
+#pragma omp parallel for default(none) shared(n_k, n_sigma, n_M, obe, mu, delta, Sigma_w, mesh, total, projected, r_all)
     for (auto k_idx : range(n_k)) {
       for (auto sigma : range(n_sigma)) {
         auto P    = obe.P.P(sigma, k_idx);
@@ -142,16 +142,16 @@ namespace triqs::modest {
           auto G_k = inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all));
 
           // Total spectral function from trace
-          data(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
+          total(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
 
-          // Orbital-resolved from projection
-          auto PGP                                 = P * nda::matrix<dcomplex>{G_k} * Pdag;
-          proj_data(sigma, k_idx, n, r_all, r_all) = (-1.0 / M_PI) * imag(PGP);
+          // Orbital-resolved from projection, diagonal in m
+          auto PGP = nda::matrix<dcomplex>{P * nda::matrix<dcomplex>{G_k} * Pdag};
+          for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = (-1.0 / M_PI) * imag(PGP(m, m));
         }
       }
     }
 
-    return {.data = data, .proj_data = proj_data};
+    return {.total = total, .projected = projected};
   }
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/postprocess.cpp
+++ b/c++/triqs_modest/postprocess.cpp
@@ -4,34 +4,12 @@
 // See LICENSE in the root of this distribution for details.
 
 #include "./postprocess.hpp"
+#include "./lattice_gf_helpers.hpp"
 #include <iostream>
 #include <atomic>
 #include <stdexcept>
 
 namespace triqs::modest {
-
-  namespace detail {
-
-    // Upfold self-energy for ALL frequencies at once for a given (k, sigma)
-    // Returns array of shape (n_w, N_nu, N_nu)
-    auto upfold_self_energy_all_freq(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, auto const &Sigma_w, long k_idx,
-                                     long sigma_idx) {
-      auto N_nu = obe.H.N_nu(sigma_idx, k_idx);
-      auto n_w  = Sigma_w(0, 0).mesh().size();
-      auto out  = nda::zeros<dcomplex>(n_w, N_nu, N_nu);
-
-      for (auto &&[alpha, R] : enumerated_sub_slices(get_struct(Sigma_w).dims(r_all, 0) | tl::to<std::vector>())) {
-        auto P         = Proj.P(sigma_idx, k_idx)(R, r_all);
-        auto Pdag      = dagger(P);
-        auto Sigma_blk = Sigma_w(alpha, sigma_idx).data();
-
-        // Batch over all frequencies
-        for (auto n : range(n_w)) { out(n, r_all, r_all) += Pdag * nda::matrix<dcomplex>{Sigma_blk(n, r_all, r_all)} * P; }
-      }
-      return out;
-    }
-
-  } // namespace detail
 
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {

--- a/c++/triqs_modest/postprocess.cpp
+++ b/c++/triqs_modest/postprocess.cpp
@@ -5,16 +5,26 @@
 
 #include "./postprocess.hpp"
 #include "./lattice_gf_helpers.hpp"
+#include "utils/defs.hpp"
 #include <iostream>
-#include <atomic>
-#include <stdexcept>
+#include <chrono>
 
 namespace triqs::modest {
 
+  // All `detail::` helpers used here (upfold_self_energy_all_freq, detect_active_subspace,
+  // compute_bare_projected, compute_sigma_active, apply_K, …) live in `lattice_gf_helpers.hpp`.
+
+  // Single-projector overload — delegates to the two-projector implementation with Proj = obe.P.
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, double mu,
+                                                  block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
+    return projected_spectral_function(obe, obe.P, mu, Sigma_w, broadening);
+  }
+
+  // Two-projector overload — the canonical implementation. Used directly for cases where Σ is
+  // upfolded by a `Proj` distinct from `obe.P`; the single-projector overload above just calls
+  // through with Proj = obe.P.
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
-    using nda::linalg::inv;
-
     auto const &mesh = Sigma_w(0, 0).mesh();
     auto n_sigma     = obe.C_space.n_sigma();
     auto n_k         = obe.H.n_k();
@@ -23,32 +33,84 @@ namespace triqs::modest {
     auto im          = dcomplex(0, 1.0);
     auto delta       = im * broadening;
 
-    // Accumulate local Green's function over k-points
-    auto gloc_result = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
+    // Accumulate local Green's function over k-points (MPI-chunked).
+    auto gloc_result       = make_block2_gf(mesh, obe.C_space.Gc_block_shape());
+    mpi::communicator comm = {};
 
-    for (auto k_idx : range(n_k)) {
-      for (auto sigma : range(n_sigma)) {
-        auto P    = obe.P.P(sigma, k_idx);
-        auto Pdag = dagger(P);
-        auto H_k  = obe.H.H(sigma, k_idx);
-        auto w_k  = obe.H.k_weights(k_idx);
-
-        // Precompute upfolded self-energy for all frequencies
-        auto PSP_all = detail::upfold_self_energy_all_freq(obe, Proj, Sigma_w, k_idx, sigma);
-
-        for (auto &&[n, w] : enumerate(mesh)) {
-          auto G_k = nda::matrix<dcomplex>{inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all))};
-          gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * (P * G_k * Pdag);
+    if (obe.H.matrix_valued) {
+      // Matrix-valued H(k): direct N_ν × N_ν inversion fallback.
+      using nda::linalg::inv;
+      for (auto k_idx : mpi::chunk(range(n_k), comm)) {
+        for (auto sigma : range(n_sigma)) {
+          auto P       = obe.P.P(sigma, k_idx);
+          auto Pdag    = dagger(P);
+          auto H_k     = obe.H.H(sigma, k_idx);
+          auto w_k     = obe.H.k_weights(k_idx);
+          auto PSP_all = detail::upfold_self_energy_all_freq(obe, Proj, Sigma_w, k_idx, sigma);
+          for (auto &&[n, w] : enumerate(mesh)) {
+            auto G_k = nda::matrix<dcomplex>{inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all))};
+            gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * (P * G_k * Pdag);
+          }
         }
       }
+    } else {
+      // Diagonal H(k): rank-reduced Woodbury per (k, σ, ω), uses two projectors:
+      //   obe.P  for the output projection (M × N_ν)
+      //   Proj   for the active rows that upfold Σ  (its first `rank` active rows form Q).
+      //
+      // Per ω:
+      //   K = Σ_a · (I − Q M₀⁻¹ Q† · Σ_a)⁻¹                                  (rank × rank)
+      //   gloc(σ, ω) += w_k · ( obe.P · M₀⁻¹ · obe.P†  +  L · K · R ),
+      //   L = obe.P · M₀⁻¹ · Q†,  R = Q · M₀⁻¹ · obe.P†   (R ≠ L† for complex ω).
+      auto decomp = get_struct(Sigma_w).dims(r_all, 0) | tl::to<std::vector>();
+      auto active = detail::detect_active_subspace(Sigma_w, decomp);
+      long rank   = active.rank;
+
+      auto omegas       = mesh | stdv::transform([&](auto w) { return dcomplex(w) + delta; }) | tl::to<std::vector>();
+      auto Sa_per_sigma = range(n_sigma) | stdv::transform([&](long sigma) { return detail::compute_sigma_active(Sigma_w, active, sigma); }) //
+         | tl::to<std::vector>();
+
+      if (comm.rank() == 0)
+        std::cerr << "projected_spectral_function: starting  (n_k=" << n_k << " n_sigma=" << n_sigma //
+                  << " n_w=" << n_w << " M=" << n_M << " rank=" << rank << ")\n";
+      auto t_start = std::chrono::steady_clock::now();
+
+      for (auto k_idx : mpi::chunk(range(n_k), comm)) {
+        for (auto sigma : range(n_sigma)) {
+          auto bare        = detail::compute_bare_projected(obe, Proj, mu, k_idx, sigma, omegas, active);
+          auto w_k         = obe.H.k_weights(k_idx);
+          auto const &Sa_n = Sa_per_sigma[sigma];
+
+          // Σ ≡ 0 short-circuit: G_loc^C = G0_PP, no correction. Avoids the 0 × 0 K-solve.
+          if (rank == 0) {
+            for (long n = 0; n < n_w; ++n) gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * bare.G0_PP(n, r_all, r_all);
+            continue;
+          }
+
+          for (long n = 0; n < n_w; ++n) {
+            auto Sa      = nda::matrix<dcomplex>{Sa_n(n, r_all, r_all)};
+            auto Yaa     = nda::matrix<dcomplex>{bare.G0_QQ(n, r_all, r_all)};
+            auto KR      = detail::apply_K(Sa, Yaa, bare.G0_QPdag(n, r_all, r_all));
+            auto L_n     = nda::matrix<dcomplex>{bare.G0_PQ(n, r_all, r_all)};
+            auto contrib = nda::matrix<dcomplex>{bare.G0_PP(n, r_all, r_all) + L_n * KR};
+            gloc_result(0, sigma).data()(n, r_all, r_all) += w_k * contrib;
+          }
+        }
+      }
+
+      auto t_end  = std::chrono::steady_clock::now();
+      double secs = std::chrono::duration<double>(t_end - t_start).count();
+      if (comm.rank() == 0) std::cerr << "projected_spectral_function: total " << secs << " s\n";
     }
+
+    // Combine per-rank partial sums.  Each rank has accumulated its own k-chunk into gloc_result.
+    gloc_result = mpi::all_reduce(gloc_result);
 
     if (auto const &S = obe.ibz_symm_ops; S) { gloc_result = S->symmetrize(gloc_result, obe.C_space.atomic_decomposition()); }
 
-    // Extract spectral functions from local Green's function
+    // Extract spectral functions from the local Green's function.
     auto total     = nda::zeros<double>(n_sigma, n_w);
     auto projected = nda::zeros<double>(n_sigma, n_w, n_M, n_M);
-
     for (auto sigma : range(n_sigma)) {
       auto const &G = gloc_result(0, sigma).data();
       for (auto &&[n, w] : enumerate(mesh)) {
@@ -61,42 +123,10 @@ namespace triqs::modest {
     return {.total = total, .projected = projected};
   }
 
-  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
-                                          double broadening) {
-    using nda::linalg::inv;
-
-    auto const &mesh = Sigma_w(0, 0).mesh() | tl::to<std::vector>();
-    auto n_sigma     = obe.C_space.n_sigma();
-    auto n_k         = obe.H.n_k();
-    auto n_w         = mesh.size();
-    auto n_bands     = obe.H.N_nu(0, 0);
-    auto delta       = dcomplex(0, broadening);
-
-    auto data = nda::zeros<double>(n_sigma, n_w, n_bands, n_bands);
-
-    for (auto k_idx : range(n_k)) {
-      for (auto sigma : range(n_sigma)) {
-        auto H_k      = obe.H.H(sigma, k_idx);
-        auto k_weight = obe.H.k_weights(k_idx);
-
-        auto PSP_all = detail::upfold_self_energy_all_freq(obe, obe.P, Sigma_w, k_idx, sigma);
-
-        for (auto &&[n, w] : enumerate(mesh)) {
-          auto G_k = inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all));
-          auto A_k = real(dcomplex(0, 1.0) * (G_k - dagger(G_k)) / (2.0 * M_PI));
-          data(sigma, n, r_all, r_all) += k_weight * A_k;
-        }
-      }
-    }
-
-    return data;
-  }
-
   spectral_function_kw spectral_function_on_high_symmetry_path(one_body_elements_on_grid const &obe, double mu,
                                                                block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening) {
-    using nda::linalg::inv;
 
-    auto const &mesh = Sigma_w(0, 0).mesh() | tl::to<std::vector>();
+    auto const &mesh = Sigma_w(0, 0).mesh();
     auto n_sigma     = obe.C_space.n_sigma();
     auto n_w         = mesh.size();
     auto n_k         = obe.H.n_k();
@@ -106,29 +136,98 @@ namespace triqs::modest {
     auto total     = nda::zeros<double>(n_sigma, n_k, n_w);
     auto projected = nda::zeros<double>(n_sigma, n_k, n_w, n_M);
 
-#pragma omp parallel for default(none) shared(n_k, n_sigma, n_M, obe, mu, delta, Sigma_w, mesh, total, projected, r_all)
-    for (auto k_idx : range(n_k)) {
+    // Each k-point's outputs land in independent slots of (total, projected).  Each MPI rank fills
+    // only its own k-chunk and leaves the other slots zero, so all_reduce(+) acts as a gather —
+    // not a sum over k in the mathematical sense.
+    mpi::communicator comm = {};
+
+    // Matrix-valued H(k): direct N_ν × N_ν inversion.
+    if (obe.H.matrix_valued) {
+      using nda::linalg::inv;
+      auto mesh_vec = mesh | tl::to<std::vector>();
+#pragma omp parallel for collapse(2) default(none) shared(comm, n_k, n_sigma, n_M, obe, mu, delta, Sigma_w, mesh_vec, total, projected, r_all)
+      for (auto k_idx : mpi::chunk(range(n_k), comm)) {
+        for (auto sigma : range(n_sigma)) {
+          auto P       = obe.P.P(sigma, k_idx);
+          auto Pdag    = dagger(P);
+          auto H_k     = obe.H.H(sigma, k_idx);
+          auto PSP_all = detail::upfold_self_energy_all_freq(obe, obe.P, Sigma_w, k_idx, sigma);
+
+          for (auto &&[n, w] : enumerate(mesh_vec)) {
+            auto G_k               = inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all));
+            total(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
+            auto PGP               = nda::matrix<dcomplex>{P * nda::matrix<dcomplex>{G_k} * Pdag};
+            for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = (-1.0 / M_PI) * imag(PGP(m, m));
+          }
+        }
+      }
+      total     = mpi::all_reduce(total);
+      projected = mpi::all_reduce(projected);
+      return {.total = total, .projected = projected};
+    }
+
+    // Diagonal H(k): rank-reduced Woodbury per (k, σ, ω).
+    auto decomp = get_struct(Sigma_w).dims(r_all, 0) | tl::to<std::vector>();
+    auto active = detail::detect_active_subspace(Sigma_w, decomp);
+    long rank   = active.rank;
+
+    auto omegas = mesh | stdv::transform([&](auto w) { return dcomplex(w) + delta; }) | tl::to<std::vector>();
+    // Σ_active across all ω, per σ. Independent of k, so build once and reuse for every k.
+    auto Sa_per_sigma = range(n_sigma) | stdv::transform([&](long sigma) { return detail::compute_sigma_active(Sigma_w, active, sigma); }) //
+       | tl::to<std::vector>();
+
+    if (comm.rank() == 0)
+      std::cerr << "spectral_function_on_high_symmetry_path: starting  (n_k=" << n_k << " n_sigma=" << n_sigma //
+                << " n_w=" << n_w << " M=" << n_M << " rank=" << rank << ")\n";
+    auto t_start = std::chrono::steady_clock::now();
+
+#pragma omp parallel for collapse(2) default(none)                                                                                                   \
+   shared(comm, n_k, n_sigma, n_M, n_w, rank, obe, mu, omegas, Sigma_w, active, Sa_per_sigma, total, projected, r_all)
+    for (auto k_idx : mpi::chunk(range(n_k), comm)) {
       for (auto sigma : range(n_sigma)) {
-        auto P    = obe.P.P(sigma, k_idx);
-        auto Pdag = dagger(P);
-        auto H_k  = obe.H.H(sigma, k_idx);
+        auto bare        = detail::compute_bare_projected(obe, obe.P, mu, k_idx, sigma, omegas, active);
+        auto const &Sa_n = Sa_per_sigma[sigma];
 
-        // Precompute upfolded self-energy for all frequencies
-        auto PSP_all = detail::upfold_self_energy_all_freq(obe, obe.P, Sigma_w, k_idx, sigma);
+        // Σ ≡ 0 short-circuit: only the bare terms contribute. Avoids the 0 × 0 K-solve.
+        if (rank == 0) {
+          for (long n = 0; n < n_w; ++n) {
+            total(sigma, k_idx, n) = -imag(bare.G0_band_trace(n)) / M_PI;
+            for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = -imag(bare.G0_PP(n, m, m)) / M_PI;
+          }
+          continue;
+        }
 
-        for (auto &&[n, w] : enumerate(mesh)) {
-          auto G_k = inv(w + delta + mu - H_k - PSP_all(n, r_all, r_all));
+        for (auto n : range(n_w)) {
+          // One K-solve for both right-hand sides — trace and band-projection — by stacking them.
+          auto Sa  = nda::matrix<dcomplex>{Sa_n(n, r_all, r_all)};
+          auto Yaa = nda::matrix<dcomplex>{bare.G0_QQ(n, r_all, r_all)};
 
-          // Total spectral function from trace
-          total(sigma, k_idx, n) = (-1.0 / M_PI) * imag(trace(G_k));
+          auto RHS                            = nda::matrix<dcomplex>::zeros(rank, rank + n_M);
+          RHS(r_all, range(0, rank))          = bare.G0_QQ_sq(n, r_all, r_all);
+          RHS(r_all, range(rank, rank + n_M)) = bare.G0_QPdag(n, r_all, r_all);
 
-          // Orbital-resolved from projection, diagonal in m
-          auto PGP = nda::matrix<dcomplex>{P * nda::matrix<dcomplex>{G_k} * Pdag};
-          for (auto m : range(n_M)) projected(sigma, k_idx, n, m) = (-1.0 / M_PI) * imag(PGP(m, m));
+          auto SaRHS   = detail::apply_K(Sa, Yaa, RHS);
+          auto X_trace = SaRHS(r_all, range(0, rank));          // K · G0_QQ_sq   (rank × rank)
+          auto KR      = SaRHS(r_all, range(rank, rank + n_M)); // K · G0_QPdag   (rank × M)
+
+          // Total: trace(G_k) = trace(M₀⁻¹) + trace(K · G0_QQ_sq).
+          total(sigma, k_idx, n) = -imag(bare.G0_band_trace(n) + nda::trace(X_trace)) / M_PI;
+
+          // Orbital diag: diag(P G_k P†) = diag(G0_PP) + diag(L · KR),  L = G0_PQ.
+          //   (L · KR)_{mm} = Σ_c L_n(m, c) · KR(c, m).
+          for (auto m : range(n_M)) {
+            dcomplex corr_m = 0;
+            for (auto c : range(rank)) corr_m += bare.G0_PQ(n, m, c) * KR(c, m);
+            projected(sigma, k_idx, n, m) = -imag(bare.G0_PP(n, m, m) + corr_m) / M_PI;
+          }
         }
       }
     }
-
+    auto t_end        = std::chrono::steady_clock::now();
+    double total_secs = std::chrono::duration<double>(t_end - t_start).count();
+    if (comm.rank() == 0) std::cerr << "spectral_function_on_high_symmetry_path: total " << total_secs << " s\n";
+    total     = mpi::all_reduce(total);
+    projected = mpi::all_reduce(projected);
     return {.total = total, .projected = projected};
   }
 

--- a/c++/triqs_modest/postprocess.hpp
+++ b/c++/triqs_modest/postprocess.hpp
@@ -8,6 +8,7 @@
 #include <nda/nda.hpp>
 #include <triqs/gfs.hpp>
 #include "./downfolding.hpp"
+#include "./obe_tb.hpp"
 
 namespace triqs::modest {
 
@@ -76,5 +77,47 @@ namespace triqs::modest {
    */
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
+
+  //-------------------------------------------------------------------------------------------
+  // OBE tight-binding overloads
+  //-------------------------------------------------------------------------------------------
+
+  /**
+   * @ingroup post
+   * @brief Compute the atom- and orbital-resolved spectral function (interacting DOS) from a tight-binding OBE.
+   *
+   * Accumulates the local Green's function on a uniform \f$\Gamma\f$-centered Monkhorst-Pack grid built from
+   * `opt.k_grid`, projects to the C-space by index-slicing the first `C_space.dim()` rows/cols of the full
+   * n_orb × n_orb Wannier matrix (the same embedding convention used by `gloc(one_body_elements_tb, ...)`),
+   * and reports both the C-space trace (`total`) and the full C-space matrix (`projected`). Adaptive
+   * integration is not supported: `opt.run_adaptive` must be `false`.
+   *
+   * @param obe One-body elements built from a tight-binding Hamiltonian.
+   * @param mu Chemical potential.
+   * @param Sigma_w Self-energy in real-frequencies.
+   * @param opt Container for BZ-integration options; `opt.k_grid` defines the uniform mesh.
+   * @param broadening Spectral broadening.
+   * @return Atom- and orbital-resolved spectral function.
+   */
+  spectral_function_w projected_spectral_function(one_body_elements_tb const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
+                                                  bz_int_options const &opt, double broadening = 0.01);
+
+  /**
+   * @ingroup post
+   * @brief Compute the momentum-resolved spectral function \f$A^\sigma(k,\omega)\f$ along a user-supplied path.
+   *
+   * H(k) is evaluated on the fly at each row of `k_list` (fractional coordinates, units of reciprocal lattice
+   * vectors). Use `triqs.lattice.utils.k_space_path` to build a path. The returned `projected` field is the
+   * diagonal in the C-space orbital index (shape `[n_sigma, n_k, n_w, n_M]`), matching the on-grid path version.
+   *
+   * @param obe One-body elements built from a tight-binding Hamiltonian.
+   * @param k_list Array of shape `[nk, 3]` of fractional k-points.
+   * @param mu Chemical potential.
+   * @param Sigma_w Self-energy in real-frequencies.
+   * @param broadening Spectral broadening.
+   * @return Momentum-resolved spectral function (total Wannier trace + C-space projection).
+   */
+  spectral_function_kw spectral_function_on_high_symmetry_path(one_body_elements_tb const &obe, nda::array<double, 2> const &k_list, double mu,
+                                                               block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/postprocess.hpp
+++ b/c++/triqs_modest/postprocess.hpp
@@ -50,8 +50,25 @@ namespace triqs::modest {
    * @ingroup post
    * @brief Compute the atom- and orbital-resolved spectral function (interacting density of states).
    *
+   * @details Common case: `obe.P` is also the projector that upfolds the self-energy.
+   * Uses the rank-reduced Woodbury fast path when `obe.H.matrix_valued == false`.
+   *
+   * @param obe One-body elements on grid.
+   * @param mu Chemical potential.
+   * @param Sigma_w Self-energy in real-frequencies.
+   * @param broadening Spectral broadening.
+   * @return Atom- and orbital-resolved spectral function.
+   */
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, double mu,
+                                                  block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
+
+  /**
+   * @ingroup post
+   * @brief Two-projector overload: uses a downfolding projector to upfold Σ and a partial projector project G_{\nu\nu'}(\omega) into the
+   * W space instead of the C space. 
+   *
    * @param obe One-body elements on grid created from one_body_elements_with_partial_projectors.
-   * @param Proj Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
+   * @param Proj Downfolding projector defined in the correlated space used to upfold the DMFT self-energies.
    * @param mu Chemical potential.
    * @param Sigma_w Self-energy in real-frequencies.
    * @param broadening Spectral broadening.
@@ -59,24 +76,5 @@ namespace triqs::modest {
    */
   spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
-
-  /**
-   * @ingroup post
-   * @brief Compute the k-summed band-resolved spectral function matrix.
-   *
-   * The returned array has shape (n_sigma, n_omega, n_bands, n_bands), with
-   *
-   * \\f[
-   *   A(\\omega) = -\\frac{1}{2\\pi i}\\left[G(\\omega) - G^{\\dagger}(\\omega)\\right].
-   * \\f]
-   *
-   * @param obe One-body elements on grid.
-   * @param mu Chemical potential.
-   * @param Sigma_w Self-energy in real-frequencies.
-   * @param broadening Spectral broadening.
-   * @return Band-resolved spectral function matrix.
-   */
-  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
-                                          double broadening = 0.01);
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/postprocess.hpp
+++ b/c++/triqs_modest/postprocess.hpp
@@ -37,9 +37,25 @@ namespace triqs::modest {
 
   /// Store data of spectral functions.
   struct spectral_function_kw {
-    nda::array<double, 3> data;      ///< \f$ A^\sigma(k,\omega) \f$.
-    nda::array<double, 5> proj_data; ///< \f$ A^\sigma(k,\omega) \f$.
+    nda::array<double, 3> total;     ///< \f$ A^\sigma(k,\omega) \f$.
+    nda::array<double, 4> projected; ///< \f$ A^\sigma_{mm}(k,\omega) \f$ (diagonal in \f$m\f$).
+    static std::string hdf5_format() { return "SpectralFunctionKw"; }
+    friend std::ostream &operator<<(std::ostream &out, spectral_function_kw const &x);
   };
+
+  /// Store data of spectral functions.
+  struct spectral_function_w {
+    nda::array<double, 2> total;     ///< \f$ A^\sigma(\omega) \f$.
+    nda::array<double, 4> projected; ///< \f$ A^{\sigma}_{mm'}(\omega) \f$.
+    static std::string hdf5_format() { return "SpectralFunctionW"; }
+    friend std::ostream &operator<<(std::ostream &out, spectral_function_w const &x);
+  };
+
+  /// h5 read and writes
+  void h5_read(h5::group g, std::string const &name, spectral_function_kw &x);
+  void h5_write(h5::group g, std::string const &name, spectral_function_kw const &x);
+  void h5_read(h5::group g, std::string const &name, spectral_function_w &x);
+  void h5_write(h5::group g, std::string const &name, spectral_function_w const &x);
 
   /**
    * @ingroup post
@@ -54,24 +70,18 @@ namespace triqs::modest {
   spectral_function_kw spectral_function_on_high_symmetry_path(one_body_elements_on_grid const &obe, double mu,
                                                                block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
 
-  /// Store data of spectral functions.
-  struct spectral_function_w {
-    nda::array<double, 2> total;     ///< \f$ A^\sigma(\omega) \f$.
-    nda::array<double, 4> per_theta; ///< \f$ A^{\sigma}_{mm'}(\omega) \f$.
-  };
-
   /**
    * @ingroup post
    * @brief Compute the atom- and orbital-resolved spectral function (interacting density of states).
    *
-   * @param obe_theta One-body elements on grid created from one_body_elements_with_theta_projectors.
+   * @param obe One-body elements on grid created from one_body_elements_with_partial_projectors.
    * @param Proj Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
    * @param mu Chemical potential.
    * @param Sigma_w Self-energy in real-frequencies.
    * @param broadening Spectral broadening.
    * @return Atom- and orbital-resolved spectral function.
    */
-  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe_theta, downfolding_projector const &Proj, double mu,
+  spectral_function_w projected_spectral_function(one_body_elements_on_grid const &obe, downfolding_projector const &Proj, double mu,
                                                   block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
 
   /**
@@ -90,7 +100,7 @@ namespace triqs::modest {
    * @param broadening Spectral broadening.
    * @return Band-resolved spectral function matrix.
    */
-  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu,
-                                          block2_gf<mesh::refreq, matrix_valued> const &Sigma_w, double broadening = 0.01);
+  nda::array<double, 4> spectral_function(one_body_elements_on_grid const &obe, double mu, block2_gf<mesh::refreq, matrix_valued> const &Sigma_w,
+                                          double broadening = 0.01);
 
 } // namespace triqs::modest

--- a/c++/triqs_modest/postprocess.hpp
+++ b/c++/triqs_modest/postprocess.hpp
@@ -11,30 +11,6 @@
 
 namespace triqs::modest {
 
-  //-------------------------------------------------------------------------------------------
-
-  /// Returns Tr (A) [σ,k,ω] for all k points in obe grid and all omega in Sigma mesh
-  // nda::array<dcomplex, 3> spectral_function(one_body_elements_on_grid const &obe, double mu,
-  //                                           // add magnetic field,
-  //                                           block2_gf<mesh::refreq, matrix_valued> const &Sigma,
-  //                                           nda::array<nda::matrix<double>, 2> const &Sigma_DC) {
-  //   auto n_sigma       = Sigma.size2();
-  //   auto const &mesh   = Sigma(0, 0).mesh();
-  //   auto calc_trace_GB = detail::trace_G_B_m_G_KS(obe, mu, Sigma, Sigma_DC);
-  //   auto result        = nda::zeros<dcomplex>(n_sigma, obe.H.n_k(), mesh.size());
-
-  //   // WRONG : need to add KS TERM ?
-  //   // FIXME : should we do it this way ???? cancelation of poles ???
-
-  //   for (auto sigma : range(n_sigma)) {
-  //     // FIXME JC : put openmp
-  //     for (auto k_idx : nda::range(obe.H.n_k()))
-  //       result(sigma, k_idx, r_all) = obe.H.k_weights(k_idx) * calc_trace_GB(sigma, k_idx);
-  //   }
-  //   result = -1 / M_PI * imag(result);
-  //   return result;
-  // }
-
   /// Store data of spectral functions.
   struct spectral_function_kw {
     nda::array<double, 3> total;     ///< \f$ A^\sigma(k,\omega) \f$.

--- a/c++/triqs_modest/printing.cpp
+++ b/c++/triqs_modest/printing.cpp
@@ -5,6 +5,7 @@
 
 #include "./downfolding.hpp"
 #include "./embedding.hpp"
+#include "./postprocess.hpp"
 #include <algorithm>
 #include <fmt/base.h>
 #include <triqs/utility/report_stream.hpp>
@@ -166,6 +167,26 @@ namespace triqs::modest {
 
   std::ostream &operator<<(std::ostream &out, embedding const &E) {
     out << E.description(false);
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  std::ostream &operator<<(std::ostream &out, spectral_function_w const &x) {
+    out << "Spectral functions on a real-frequency mesh [spectral_function_w]:\n";
+    auto out1 = triqs::utility::indented_ostream(out, 2);
+    out1 << fmt::format("total[σ, ω]            A^σ(ω)         shape = {}\n", x.total.shape());
+    out1 << fmt::format("projected[σ, ω, m, m'] A^σ_mm'(ω)     shape = {}\n", x.projected.shape());
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+
+  std::ostream &operator<<(std::ostream &out, spectral_function_kw const &x) {
+    out << "Momentum-resolved spectral functions on a real-frequency mesh [spectral_function_kw]:\n";
+    auto out1 = triqs::utility::indented_ostream(out, 2);
+    out1 << fmt::format("total[σ, k, ω]              A^σ(k, ω)       shape = {}\n", x.total.shape());
+    out1 << fmt::format("projected[σ, k, ω, m]       A^σ_mm(k, ω)    shape = {}\n", x.projected.shape());
     return out;
   }
 

--- a/c++/triqs_modest/printing.cpp
+++ b/c++/triqs_modest/printing.cpp
@@ -95,7 +95,7 @@ namespace triqs::modest {
     auto out2 = triqs::utility::indented_ostream(out, 4);
     out << "One body elements tight-binding: Fourier representation of one-body dispersion [one_body_elements_tb]\n";
     out1 << "H^σ(k):\n";
-    for (auto &h : obe.H) { out2 << h; }
+    for (auto &h : obe.H) { out2 << h << "\n"; }
     out1 << "C_space:\n";
     out2 << obe.C_space;
     return out;

--- a/c++/triqs_modest/printing.cpp
+++ b/c++/triqs_modest/printing.cpp
@@ -2,7 +2,7 @@
 // This file is part of TRIQS/modest and is licensed under the terms of GPLv3 or later.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // See LICENSE in the root of this distribution for details.
-
+#include "./obe_tb.hpp"
 #include "./downfolding.hpp"
 #include "./embedding.hpp"
 #include "./postprocess.hpp"
@@ -87,6 +87,28 @@ namespace triqs::modest {
     out2 << obe.P;
     out1 << fmt::format("IBZ = {}\n", bool(obe.ibz_symm_ops));
     if (obe.ibz_symm_ops) { out2 << obe.ibz_symm_ops.value(); };
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, one_body_elements_tb const &obe) {
+    auto out1 = triqs::utility::indented_ostream(out, 2); // same stream, but shifted by 2 spaces
+    auto out2 = triqs::utility::indented_ostream(out, 4);
+    out << "One body elements tight-binding: Fourier representation of one-body dispersion [one_body_elements_tb]\n";
+    out1 << "H^σ(k):\n";
+    for (auto &h : obe.H) { out2 << h; }
+    out1 << "C_space:\n";
+    out2 << obe.C_space;
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, one_body_elements_gw const &obe) {
+    auto out1 = triqs::utility::indented_ostream(out, 2); // same stream, but shifted by 2 spaces
+    auto out2 = triqs::utility::indented_ostream(out, 4);
+    out << "One body elements GW: [one_body_elements_gw]\n";
+    out1 << "C_space:\n";
+    out2 << obe.C_space;
+    out1 << "P:\n";
+    out2 << obe.P;
     return out;
   }
 

--- a/doc/reference/python/checkpointing.rst
+++ b/doc/reference/python/checkpointing.rst
@@ -3,10 +3,55 @@
 Checkpointing
 *************
 
-HDF5-based checkpointing for DMFT calculations: iteration containers and
-the checkpoint manager base class.
+HDF5-based checkpointing for DMFT calculations. ModEST exposes two
+classes:
+
+* :py:class:`~triqs_modest.utils.file_io.CheckpointBase` — the
+  ``c2py``-wrapped C++ checkpoint manager. Use it directly for pure
+  C++ workflows or single-rank Python scripts.
+* :py:class:`~triqs_modest.utils.checkpoint.Checkpointer` — a
+  Python wrapper around ``CheckpointBase`` that is safe to call on all
+  MPI ranks, supports a create-or-open constructor with optional initial
+  data, accepts arbitrary keyword extras via :py:class:`h5.HDFArchive`,
+  and exposes the convergence-log helper ``summarize()``.
 
 .. autosummary::
 
    triqs_modest.utils.file_io.IterationData
    triqs_modest.utils.file_io.CheckpointBase
+   triqs_modest.utils.checkpoint.Checkpointer
+
+Iteration data
+==============
+
+Each iteration stored in the checkpoint is an
+:py:class:`~triqs_modest.utils.file_io.IterationData` carrying the
+restart-required fields and several optional diagnostic / CSC fields:
+
+* **Restart payload** (always populated):
+  ``mu``, ``Sigma_imp_list``, ``Sigma_hartree_list``, ``Sigma_dc_list``.
+  ``Sigma_dc_list`` is ``[]`` for non-CSC runs and populated for CSC.
+* **Solver outputs** (optional):
+  ``Gimp_list`` — impurity Green's functions returned by the solver.
+* **Solver inputs** (optional):
+  ``Gloc_list`` — local Green's function fed to the solver;
+  ``Delta_list`` — hybridization function fed to the solver.
+
+Optional fields default to empty lists. Simple DMFT runs can ignore
+them; CSC and machine-learning workflows fill them in.
+
+The on-disk HDF5 layout reflects this split: each iteration is written
+under ``<name>/inputs/{Gloc_list, Delta_list}`` and
+``<name>/outputs/{Gimp_list, Sigma_imp_list, Sigma_hartree_list,
+Sigma_dc_list}``.
+
+Diagnostics
+===========
+
+:py:meth:`~triqs_modest.utils.checkpoint.Checkpointer.summarize` prints
+a per-iteration convergence log to ``stdout`` (or a user-supplied
+stream). Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+skipped if no iteration has the corresponding list populated, and
+``--`` placeholders appear for iterations whose individual lists are
+empty. The call is a no-op on non-master ranks.

--- a/doc/reference/python/one_body_elements.rst
+++ b/doc/reference/python/one_body_elements.rst
@@ -24,7 +24,7 @@ Factories
 
    triqs_modest.obe.one_body_elements_from_dft_converter
    triqs_modest.obe.one_body_elements_on_high_symmetry_path
-   triqs_modest.obe.one_body_elements_with_theta_projectors
+   triqs_modest.obe.one_body_elements_with_partial_projectors
    triqs_modest.obe.make_one_body_elements_gw
    triqs_modest.obe_tb.one_body_elements_from_wannier90
 
@@ -48,3 +48,15 @@ Supporting types
    triqs_modest.obe.LocalSpace
    triqs_modest.obe.AtomicOrbs
    triqs_modest.obe.IbzSymmetryOps
+
+Operations
+==========
+
+Apply a unitary rotation :math:`U` to the local correlated basis of an
+existing :py:class:`~triqs_modest.obe.OneBodyElementsOnGrid` (or its
+:py:class:`~triqs_modest.obe.IbzSymmetryOps`). The projector
+:math:`P(\mathbf{k})` is transformed as in :eq:`eq_ChangeBasisP`.
+
+.. autosummary::
+
+   triqs_modest.obe.rotate_local_basis

--- a/doc/reference/python/post_processing.rst
+++ b/doc/reference/python/post_processing.rst
@@ -42,6 +42,16 @@ on the chosen path,
 where :math:`G_{\mathcal{B}}^{\sigma}` is evaluated on the
 high-symmetry path with the analytically-continued self-energy.
 
+Both functions accept either a
+:py:class:`~triqs_modest.obe.OneBodyElementsOnGrid` (DFT / Wannier90
+input, where the projector :math:`P(\mathbf{k})` performs the
+downfolding from :math:`\mathcal{B}` to :math:`\mathcal{C}`) or a
+:py:class:`~triqs_modest.obe_tb.OneBodyElementsTb` (tight-binding
+input). In the tight-binding case there is no downfolding projector;
+the embedded self-energy is placed directly into the Wannier basis by
+index-slicing, and :math:`\mathcal{C}` is identified with the subset
+of Wannier orbitals on which :math:`\Sigma` is non-zero.
+
 .. autosummary::
 
    triqs_modest.post_processing.projected_spectral_function
@@ -49,6 +59,15 @@ high-symmetry path with the analytically-continued self-energy.
 
 Container types
 ===============
+
+The output containers carry two views of the spectral function:
+
+* ``total`` — the scalar (band / Wannier) trace
+  :math:`A^{\sigma}(\omega)` or :math:`A^{\sigma}(\mathbf{k}, \omega)`.
+* ``projected`` — the matrix in :math:`\mathcal{C}`,
+  :math:`A^{\sigma}_{m m'}(\omega)` for ``SpectralFunctionW`` or the
+  diagonal :math:`A^{\sigma}_{m m}(\mathbf{k}, \omega)` for
+  ``SpectralFunctionKw``.
 
 .. autosummary::
 

--- a/python/triqs_modest/local_gf.wrap.cxx
+++ b/python/triqs_modest/local_gf.wrap.cxx
@@ -38,6 +38,19 @@ static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{c2py::cfun(
 // gloc
 static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
    c2py::cfun(
+      [](const triqs::modest::one_body_elements_tb &obe, double mu,
+         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
+         const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
+         const triqs::experimental::lattice::bz_int_options &opt) {
+        return triqs::modest::gloc<triqs::mesh::imfreq>(obe, mu, Sigma_dynamic, Sigma_static, opt);
+      },
+      "obe", "mu", "Sigma_dynamic", "Sigma_static", "opt"),
+   c2py::cfun([](const triqs::mesh::imfreq &mesh, const triqs::modest::one_body_elements_tb &obe, double mu,
+                 const triqs::experimental::lattice::bz_int_options &opt) { return triqs::modest::gloc<triqs::mesh::imfreq>(mesh, obe, mu, opt); },
+              "mesh", "obe", "mu", "opt"),
+   c2py::cfun(
       [](const triqs::modest::one_body_elements_on_grid &obe, double mu,
          const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
          const nda::basic_array<
@@ -60,20 +73,7 @@ static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
               "mesh", "obe", "mu"),
    c2py::cfun([](const triqs::mesh::dlr_imfreq &mesh, const triqs::modest::one_body_elements_on_grid &obe,
                  double mu) { return triqs::modest::gloc<triqs::mesh::dlr_imfreq>(mesh, obe, mu); },
-              "mesh", "obe", "mu"),
-   c2py::cfun(
-      [](const triqs::modest::one_body_elements_tb &obe, double mu,
-         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
-         const nda::basic_array<
-            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
-            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
-         const triqs::experimental::lattice::bz_int_options &opt) {
-        return triqs::modest::gloc<triqs::mesh::imfreq>(obe, mu, Sigma_dynamic, Sigma_static, opt);
-      },
-      "obe", "mu", "Sigma_dynamic", "Sigma_static", "opt"),
-   c2py::cfun([](const triqs::mesh::imfreq &mesh, const triqs::modest::one_body_elements_tb &obe, double mu,
-                 const triqs::experimental::lattice::bz_int_options &opt) { return triqs::modest::gloc<triqs::mesh::imfreq>(mesh, obe, mu, opt); },
-              "mesh", "obe", "mu", "opt")};
+              "mesh", "obe", "mu")};
 
 static const auto _c2py_doc_0 = _c2py_fun_0.doc(
    R"DOC(
@@ -107,7 +107,13 @@ Returns
       nda::basic_array<std::complex<double>, 4, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
 static const auto _c2py_doc_1 = _c2py_fun_1.doc(
    R"DOC(
-[1, 2] Compute local Green's function on a :math:`M \times M` mesh.
+[1, 2, 5, 6] Compute the local Green's function without a self-energy.
+
+See other overloads (gloc) for more details.
+
+------
+
+[3, 4] Compute local Green's function on a :math:`M \times M` mesh.
 
 When the one-body dispersion is defined as fixed k-grid, which is the case when working with DFT codes
 (e.g., VASP, Wien2k, Elk) or performing charge self-consistent calculations with any DFT code, :math:`H(\mathbf{k})`
@@ -125,16 +131,10 @@ using the Woodbury formula which allows us to perform the matrix inversion in th
 
 ------
 
-[3, 4, 5, 6] Compute the local Green's function without a self-energy.
-
-See other overloads (gloc) for more details.
-
-------
-
 Parameters
 ----------
 obe : {par_0}
-   One-body elements on a fixed grid.
+   One-body elements containing the TB Hamiltonian.
 mu : {par_1}
    Chemical potential :math:`\mu`.
 Sigma_dynamic : {par_2}
@@ -143,37 +143,37 @@ Sigma_dynamic : {par_2}
 Sigma_static : {par_3}
    The static part of the embedded self-energy in the embedded view,
    :math:`\Sigma_{\text{static}}[\alpha,\sigma]`.
-mesh : {par_4}
-   (DLR) imaginary frequency mesh.
-opt : {par_5}
+opt : {par_4}
    Container for options related to integration of the BZ.
+mesh : {par_5}
+   The mesh on which :math:`G_{\mathrm{loc}}` will be computed.
 
 Returns
 -------
-[1] : {ret_0}
-   :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function in the full :math:`\mathcal{C}` space.
-
-[2] : {ret_1}
-   :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function in the full :math:`\mathcal{C}` space.
-
-[3, 5, 6] : {ret_2}
+[1, 2, 5] : {ret_0}
    :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function.
 
-[4] : {ret_3}
+[3] : {ret_1}
+   :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function in the full :math:`\mathcal{C}` space.
+
+[4] : {ret_2}
+   :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function in the full :math:`\mathcal{C}` space.
+
+[6] : {ret_3}
    :math:`G_{\mathrm{loc}}^{\sigma}`, the local Green's function.
 )DOC",
-   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
+   {{c2py::python_typename<const triqs::modest::one_body_elements_tb &>()},
     {c2py::python_typename<double>()},
     {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>(),
      c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
     {c2py::python_typename<const nda::basic_array<
        nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
        nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &>()},
-    {c2py::python_typename<const triqs::mesh::imfreq &>(), c2py::python_typename<const triqs::mesh::dlr_imfreq &>()},
-    {c2py::python_typename<const triqs::experimental::lattice::bz_int_options &>()}},
+    {c2py::python_typename<const triqs::experimental::lattice::bz_int_options &>()},
+    {c2py::python_typename<const triqs::mesh::imfreq &>()}},
    {c2py::python_typename<triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2>>(),
-    c2py::python_typename<triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2>>(),
     c2py::python_typename<triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2>>(),
+    c2py::python_typename<triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2>>(),
     c2py::python_typename<triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2>>()});
 //--------------------- module function table  -----------------------------
 

--- a/python/triqs_modest/obe.toml
+++ b/python/triqs_modest/obe.toml
@@ -27,7 +27,7 @@ namespaces = "triqs triqs::modest"
 #    if reject_names and reject_names match Qname : skip X
 #    else keep X.
 
-match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
+match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|rotate_local_basis|spin_kind_e)"
 
 # Only keep elements declared in files matching the pattern
 # match_files = "" # String must be a regex

--- a/python/triqs_modest/obe.toml
+++ b/python/triqs_modest/obe.toml
@@ -27,7 +27,7 @@ namespaces = "triqs triqs::modest"
 #    if reject_names and reject_names match Qname : skip X
 #    else keep X.
 
-match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_theta_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
+match_names = "triqs::modest::(atomic_orbs|ibz_symmetry_ops|band_dispersion|downfolding_projector|downfolding_projector_ext|local_space|one_body_elements_on_grid|one_body_elements_from_dft_converter|one_body_elements_gw|make_one_body_elements_gw|one_body_elements_with_partial_projectors|one_body_elements_on_high_symmetry_path|spin_kind_e)"
 
 # Only keep elements declared in files matching the pattern
 # match_files = "" # String must be a regex

--- a/python/triqs_modest/obe.wrap.cxx
+++ b/python/triqs_modest/obe.wrap.cxx
@@ -117,14 +117,14 @@ template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
 template <> inline constexpr auto c2py::tp_name<_c2py_cls_1> = "triqs_modest.obe.LocalSpace";
 static const auto _c2py_init_0                               = c2py::dispatcher_c_kw_t{
    c2py::c_constructor<_c2py_cls_1, triqs::modest::spin_kind_e, std::vector<triqs::modest::atomic_orbs>,
-                       nda::basic_array<std::vector<long, std::allocator<long>>, 2, nda::C_layout, 'A',
-                                        nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                       nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
-                                                         nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                                        2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                       nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
-                                                         nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
-                                        1, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(
+                                                     nda::basic_array<std::vector<long, std::allocator<long>>, 2, nda::C_layout, 'A',
+                                                                      nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                     nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
+                                                                                       nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                                      2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                     nda::basic_array<nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M',
+                                                                                       nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>,
+                                                                      1, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(
       "spin_kind", "atomic_shells", "irreps_decomp_per_atom", "rotation_from_dft_to_local_basis", "rotation_from_spherical_to_dft_basis"),
    c2py::c_constructor<_c2py_cls_1>()};
 template <> constexpr initproc c2py::tp_init<_c2py_cls_1> = c2py::pyfkw_constructor<_c2py_init_0>;
@@ -948,10 +948,10 @@ static auto const _c2py_fun_8 = c2py::dispatcher_f_kw_t{c2py::cfun(
    },
    "filename", "obe")};
 
-// one_body_elements_with_theta_projectors
+// one_body_elements_with_partial_projectors
 static auto const _c2py_fun_9 = c2py::dispatcher_f_kw_t{c2py::cfun(
    [](const std::string &filename, const triqs::modest::one_body_elements_on_grid &obe) {
-     return triqs::modest::one_body_elements_with_theta_projectors(filename, obe);
+     return triqs::modest::one_body_elements_with_partial_projectors(filename, obe);
    },
    "filename", "obe")};
 
@@ -1054,7 +1054,7 @@ Returns
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
 static const auto _c2py_doc_9 =
    _c2py_fun_9.doc(R"DOC(
-Create a one-body elements with the :math:`\Theta` projectors.
+Create a one-body elements with partial (all-atom) projectors.
 
 Using the data from the "dft_parproj_input" group, the local space, downfolding projectors,
 and optional IBZ symmetry ops are prepared to create a one-body elements. This object is
@@ -1070,7 +1070,7 @@ obe : {par_1}
 Returns
 -------
 {ret_0}
-   One-body elements using the :math:`\Theta` projectors.
+   One-body elements using the partial projectors.
 )DOC",
                    {{c2py::python_typename<const std::string &>()}, {c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()}},
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
@@ -1080,7 +1080,7 @@ static PyMethodDef module_methods[] = {
    {"make_one_body_elements_gw", (PyCFunction)c2py::pyfkw<_c2py_fun_6>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_6.c_str()},
    {"one_body_elements_from_dft_converter", (PyCFunction)c2py::pyfkw<_c2py_fun_7>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_7.c_str()},
    {"one_body_elements_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_8>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_8.c_str()},
-   {"one_body_elements_with_theta_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
+   {"one_body_elements_with_partial_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/python/triqs_modest/obe.wrap.cxx
+++ b/python/triqs_modest/obe.wrap.cxx
@@ -955,6 +955,21 @@ static auto const _c2py_fun_9 = c2py::dispatcher_f_kw_t{c2py::cfun(
    },
    "filename", "obe")};
 
+// rotate_local_basis
+static auto const _c2py_fun_10 = c2py::dispatcher_f_kw_t{
+   c2py::cfun(
+      [](const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &U,
+         const triqs::modest::ibz_symmetry_ops &x) { return triqs::modest::rotate_local_basis(U, x); },
+      "U", "x"),
+   c2py::cfun(
+      [](const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &U,
+         const triqs::modest::one_body_elements_on_grid &x) { return triqs::modest::rotate_local_basis(U, x); },
+      "U", "x")};
+
 static const auto _c2py_doc_6 =
    _c2py_fun_6.doc(R"DOC(
 Create a one-body elements for GW calculations with CoQui.
@@ -1074,6 +1089,33 @@ Returns
 )DOC",
                    {{c2py::python_typename<const std::string &>()}, {c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()}},
                    {c2py::python_typename<triqs::modest::one_body_elements_on_grid>()});
+static const auto _c2py_doc_10 = _c2py_fun_10.doc(
+   R"DOC(
+[1] Change basis
+
+------
+
+[2] Rotates the local basis of the downfolding projector
+
+------
+
+Parameters
+----------
+U : {par_0}
+   Rotations by block in atomic decomposition
+x : {par_1}
+   ibz_symmetry_ops to rotate
+
+Returns
+-------
+{ret_0}
+   A new symmetrizer operating in the rotated basis U^† U
+)DOC",
+   {{c2py::python_typename<const nda::basic_array<
+       nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+       nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &>()},
+    {c2py::python_typename<const triqs::modest::ibz_symmetry_ops &>()}},
+   {c2py::python_typename<triqs::modest::ibz_symmetry_ops>()});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {
@@ -1081,6 +1123,7 @@ static PyMethodDef module_methods[] = {
    {"one_body_elements_from_dft_converter", (PyCFunction)c2py::pyfkw<_c2py_fun_7>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_7.c_str()},
    {"one_body_elements_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_8>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_8.c_str()},
    {"one_body_elements_with_partial_projectors", (PyCFunction)c2py::pyfkw<_c2py_fun_9>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_9.c_str()},
+   {"rotate_local_basis", (PyCFunction)c2py::pyfkw<_c2py_fun_10>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_10.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/python/triqs_modest/obe_tb.wrap.cxx
+++ b/python/triqs_modest/obe_tb.wrap.cxx
@@ -29,7 +29,7 @@ template <> inline constexpr auto c2py::tp_name<_c2py_cls_0> = "triqs_modest.obe
 static const auto _c2py_init_0                               = c2py::dispatcher_c_kw_t{
    c2py::c_constructor<_c2py_cls_0, std::vector<triqs::experimental::lattice::tb_hk>, triqs::modest::local_space>("H_sigma", "ls"),
    c2py::c_constructor<_c2py_cls_0, std::vector<triqs::experimental::lattice::tb_hk>, triqs::modest::spin_kind_e,
-                       std::vector<triqs::modest::atomic_orbs>>("H_sigma", "spin_kind", "atomic_shells")};
+                                                     std::vector<triqs::modest::atomic_orbs>>("H_sigma", "spin_kind", "atomic_shells")};
 template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = c2py::pyfkw_constructor<_c2py_init_0>;
 template <>
 const std::string c2py::tp_ctor_doc<_c2py_cls_0> = _c2py_init_0.doc(R"DOC(

--- a/python/triqs_modest/post_processing.wrap.cxx
+++ b/python/triqs_modest/post_processing.wrap.cxx
@@ -179,14 +179,24 @@ static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
    c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, const triqs::modest::downfolding_projector &Proj, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
                  double broadening) { return triqs::modest::projected_spectral_function(obe, Proj, mu, Sigma_w, broadening); },
-              "obe", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
+              "obe", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01),
+   c2py::cfun([](const triqs::modest::one_body_elements_tb &obe, double mu,
+                 const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
+                 const triqs::experimental::lattice::bz_int_options &opt,
+                 double broadening) { return triqs::modest::projected_spectral_function(obe, mu, Sigma_w, opt, broadening); },
+              "obe", "mu", "Sigma_w", "opt", "broadening"_a = 0.01)};
 
 // spectral_function_on_high_symmetry_path
 static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
    c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
                  double broadening) { return triqs::modest::spectral_function_on_high_symmetry_path(obe, mu, Sigma_w, broadening); },
-              "obe", "mu", "Sigma_w", "broadening"_a = 0.01)};
+              "obe", "mu", "Sigma_w", "broadening"_a = 0.01),
+   c2py::cfun([](const triqs::modest::one_body_elements_tb &obe,
+                 const nda::basic_array<double, 2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &k_list,
+                 double mu, const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
+                 double broadening) { return triqs::modest::spectral_function_on_high_symmetry_path(obe, k_list, mu, Sigma_w, broadening); },
+              "obe", "k_list", "mu", "Sigma_w", "broadening"_a = 0.01)};
 
 static const auto _c2py_doc_0 =
    _c2py_fun_0.doc(R"DOC(
@@ -202,6 +212,16 @@ W space instead of the C space.
 
 ------
 
+[3] Compute the atom- and orbital-resolved spectral function (interacting DOS) from a tight-binding OBE.
+
+Accumulates the local Green's function on a uniform :math:`\Gamma`-centered Monkhorst-Pack grid built from
+`opt.k_grid`, projects to the C-space by index-slicing the first `C_space.dim()` rows/cols of the full
+n_orb × n_orb Wannier matrix (the same embedding convention used by `gloc(one_body_elements_tb, ...)`),
+and reports both the C-space trace (`total`) and the full C-space matrix (`projected`). Adaptive
+integration is not supported: `opt.run_adaptive` must be `false`.
+
+------
+
 Parameters
 ----------
 obe : {par_0}
@@ -214,6 +234,8 @@ broadening : {par_3}
    Spectral broadening.
 Proj : {par_4}
    Downfolding projector defined in the correlated space used to upfold the DMFT self-energies.
+opt : {par_5}
+   Container for BZ-integration options; `opt.k_grid` defines the uniform mesh.
 
 Returns
 -------
@@ -224,11 +246,22 @@ Returns
                     {c2py::python_typename<double>()},
                     {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
                     {c2py::python_typename<double>()},
-                    {c2py::python_typename<const triqs::modest::downfolding_projector &>()}},
+                    {c2py::python_typename<const triqs::modest::downfolding_projector &>()},
+                    {c2py::python_typename<const triqs::experimental::lattice::bz_int_options &>()}},
                    {c2py::python_typename<triqs::modest::spectral_function_w>()});
-static const auto _c2py_doc_1 =
-   _c2py_fun_1.doc(R"DOC(
-Compute momentum-resolved spectral function :math:`A^\sigma(k, \omega)` along high-symmetry path.
+static const auto _c2py_doc_1 = _c2py_fun_1.doc(
+   R"DOC(
+[1] Compute momentum-resolved spectral function :math:`A^\sigma(k, \omega)` along high-symmetry path.
+
+------
+
+[2] Compute the momentum-resolved spectral function :math:`A^\sigma(k,\omega)` along a user-supplied path.
+
+H(k) is evaluated on the fly at each row of `k_list` (fractional coordinates, units of reciprocal lattice
+vectors). Use `triqs.lattice.utils.k_space_path` to build a path. The returned `projected` field is the
+diagonal in the C-space orbital index (shape `[n_sigma, n_k, n_w, n_M]`), matching the on-grid path version.
+
+------
 
 Parameters
 ----------
@@ -240,17 +273,24 @@ Sigma_w : {par_2}
    Self-energy in real-frequencies.
 broadening : {par_3}
    Spectral broadening.
+k_list : {par_4}
+   Array of shape `[nk, 3]` of fractional k-points.
 
 Returns
 -------
-{ret_0}
+[1] : {ret_0}
    Momentum-resolved spectral function.
+
+[2] : {ret_1}
+   Momentum-resolved spectral function (total Wannier trace + C-space projection).
 )DOC",
-                   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
-                    {c2py::python_typename<double>()},
-                    {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
-                    {c2py::python_typename<double>()}},
-                   {c2py::python_typename<triqs::modest::spectral_function_kw>()});
+   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
+    {c2py::python_typename<double>()},
+    {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
+    {c2py::python_typename<double>()},
+    {c2py::python_typename<
+       const nda::basic_array<double, 2, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &>()}},
+   {c2py::python_typename<triqs::modest::spectral_function_kw>(), c2py::python_typename<triqs::modest::spectral_function_kw>()});
 //--------------------- module function table  -----------------------------
 
 static PyMethodDef module_methods[] = {

--- a/python/triqs_modest/post_processing.wrap.cxx
+++ b/python/triqs_modest/post_processing.wrap.cxx
@@ -172,20 +172,17 @@ const std::string c2py::tp_doc<_c2py_cls_1> =
 
 // projected_spectral_function
 static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
+   c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, double mu,
+                 const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
+                 double broadening) { return triqs::modest::projected_spectral_function(obe, mu, Sigma_w, broadening); },
+              "obe", "mu", "Sigma_w", "broadening"_a = 0.01),
    c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, const triqs::modest::downfolding_projector &Proj, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
                  double broadening) { return triqs::modest::projected_spectral_function(obe, Proj, mu, Sigma_w, broadening); },
               "obe", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
 
-// spectral_function
-static auto const _c2py_fun_1 =
-   c2py::dispatcher_f_kw_t{c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, double mu,
-                                         const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
-                                         double broadening) { return triqs::modest::spectral_function(obe, mu, Sigma_w, broadening); },
-                                      "obe", "mu", "Sigma_w", "broadening"_a = 0.01)};
-
 // spectral_function_on_high_symmetry_path
-static auto const _c2py_fun_2 = c2py::dispatcher_f_kw_t{
+static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
    c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
                  double broadening) { return triqs::modest::spectral_function_on_high_symmetry_path(obe, mu, Sigma_w, broadening); },
@@ -193,41 +190,17 @@ static auto const _c2py_fun_2 = c2py::dispatcher_f_kw_t{
 
 static const auto _c2py_doc_0 =
    _c2py_fun_0.doc(R"DOC(
-Compute the atom- and orbital-resolved spectral function (interacting density of states).
+[1] Compute the atom- and orbital-resolved spectral function (interacting density of states).
 
-Parameters
-----------
-obe : {par_0}
-   One-body elements on grid created from one_body_elements_with_partial_projectors.
-Proj : {par_1}
-   Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
-mu : {par_2}
-   Chemical potential.
-Sigma_w : {par_3}
-   Self-energy in real-frequencies.
-broadening : {par_4}
-   Spectral broadening.
+Common case: `obe.P` is also the projector that upfolds the self-energy.
+Uses the rank-reduced Woodbury fast path when `obe.H.matrix_valued == false`.
 
-Returns
--------
-{ret_0}
-   Atom- and orbital-resolved spectral function.
-)DOC",
-                   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
-                    {c2py::python_typename<const triqs::modest::downfolding_projector &>()},
-                    {c2py::python_typename<double>()},
-                    {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
-                    {c2py::python_typename<double>()}},
-                   {c2py::python_typename<triqs::modest::spectral_function_w>()});
-static const auto _c2py_doc_1 = _c2py_fun_1.doc(
-   R"DOC(
-Compute the k-summed band-resolved spectral function matrix.
+------
 
-The returned array has shape (n_sigma, n_omega, n_bands, n_bands), with
+[2] Two-projector overload: uses a downfolding projector to upfold Σ and a partial projector project G_{'}() into the
+W space instead of the C space.
 
-\f[
-  A(\omega) = -\frac{1}{2\pi i}\left[G(\omega) - G^{\dagger}(\omega)\right].
-\f]
+------
 
 Parameters
 ----------
@@ -239,19 +212,22 @@ Sigma_w : {par_2}
    Self-energy in real-frequencies.
 broadening : {par_3}
    Spectral broadening.
+Proj : {par_4}
+   Downfolding projector defined in the correlated space used to upfold the DMFT self-energies.
 
 Returns
 -------
 {ret_0}
-   Band-resolved spectral function matrix.
+   Atom- and orbital-resolved spectral function.
 )DOC",
-   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
-    {c2py::python_typename<double>()},
-    {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
-    {c2py::python_typename<double>()}},
-   {c2py::python_typename<nda::basic_array<double, 4, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
-static const auto _c2py_doc_2 =
-   _c2py_fun_2.doc(R"DOC(
+                   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
+                    {c2py::python_typename<double>()},
+                    {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
+                    {c2py::python_typename<double>()},
+                    {c2py::python_typename<const triqs::modest::downfolding_projector &>()}},
+                   {c2py::python_typename<triqs::modest::spectral_function_w>()});
+static const auto _c2py_doc_1 =
+   _c2py_fun_1.doc(R"DOC(
 Compute momentum-resolved spectral function :math:`A^\sigma(k, \omega)` along high-symmetry path.
 
 Parameters
@@ -279,8 +255,7 @@ Returns
 
 static PyMethodDef module_methods[] = {
    {"projected_spectral_function", (PyCFunction)c2py::pyfkw<_c2py_fun_0>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_0.c_str()},
-   {"spectral_function", (PyCFunction)c2py::pyfkw<_c2py_fun_1>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_1.c_str()},
-   {"spectral_function_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_2>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_2.c_str()},
+   {"spectral_function_on_high_symmetry_path", (PyCFunction)c2py::pyfkw<_c2py_fun_1>, METH_VARARGS | METH_KEYWORDS, _c2py_doc_1.c_str()},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 

--- a/python/triqs_modest/post_processing.wrap.cxx
+++ b/python/triqs_modest/post_processing.wrap.cxx
@@ -15,6 +15,7 @@
 #define C2PY_VERSION_MINOR 1
 
 #include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
 
 using c2py::operator""_a;
 
@@ -41,8 +42,8 @@ static int synth_constructor_0(PyObject *self, PyObject *args, PyObject *kwargs)
     return -1;
   }
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
-  de("data", self_c.data, false);
-  de("proj_data", self_c.proj_data, false);
+  de("total", self_c.total, false);
+  de("projected", self_c.projected, false);
   return de.check();
 }
 
@@ -54,29 +55,31 @@ const std::string c2py::tp_ctor_doc<_c2py_cls_0> = c2py::replace_tags(
 
 Parameters
 ----------
-data : {par_0}
+total : {par_0}
 
-proj_data : {par_1}
+projected : {par_1}
 
 )DOC",
    "par",
    {c2py::python_typename<nda::basic_array<double, 3, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>(),
-    c2py::python_typename<nda::basic_array<double, 5, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
+    c2py::python_typename<nda::basic_array<double, 4, nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>>()});
 
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
 constexpr auto _c2py_doc_member_0 = R"DOC(:math:`A^\sigma(k,\omega)`.)DOC";
-constexpr auto _c2py_doc_member_1 = R"DOC(:math:`A^\sigma(k,\omega)`.)DOC";
+constexpr auto _c2py_doc_member_1 = R"DOC(:math:`A^\sigma_{mm}(k,\omega)` (diagonal in :math:`m`).)DOC";
 static PyObject *prop_get_dict_0(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
   c2py::pydict dic;
-  dic["data"]      = self_c.data;
-  dic["proj_data"] = self_c.proj_data;
+  dic["total"]     = self_c.total;
+  dic["projected"] = self_c.projected;
   return dic.new_ref();
 }
 
@@ -84,8 +87,8 @@ static PyObject *prop_get_dict_0(PyObject *self, void *) {
 
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {
-   c2py::getsetdef_from_member<&_c2py_cls_0::data, _c2py_cls_0>("data", _c2py_doc_member_0),
-   c2py::getsetdef_from_member<&_c2py_cls_0::proj_data, _c2py_cls_0>("proj_data", _c2py_doc_member_1),
+   c2py::getsetdef_from_member<&_c2py_cls_0::total, _c2py_cls_0>("total", _c2py_doc_member_0),
+   c2py::getsetdef_from_member<&_c2py_cls_0::projected, _c2py_cls_0>("projected", _c2py_doc_member_1),
    {"__dict__", (getter)prop_get_dict_0, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -112,7 +115,7 @@ static int synth_constructor_1(PyObject *self, PyObject *args, PyObject *kwargs)
   }
   auto &self_c = *(((c2py::wrap<_c2py_cls_1> *)self)->_c);
   de("total", self_c.total, false);
-  de("per_theta", self_c.per_theta, false);
+  de("projected", self_c.projected, false);
   return de.check();
 }
 
@@ -126,7 +129,7 @@ Parameters
 ----------
 total : {par_0}
 
-per_theta : {par_1}
+projected : {par_1}
 
 )DOC",
    "par",
@@ -136,7 +139,9 @@ per_theta : {par_1}
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_1>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_1>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_1>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_1>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
@@ -146,7 +151,7 @@ static PyObject *prop_get_dict_1(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_1> *)self)->_c);
   c2py::pydict dic;
   dic["total"]     = self_c.total;
-  dic["per_theta"] = self_c.per_theta;
+  dic["projected"] = self_c.projected;
   return dic.new_ref();
 }
 
@@ -155,7 +160,7 @@ static PyObject *prop_get_dict_1(PyObject *self, void *) {
 template <>
 constinit PyGetSetDef c2py::tp_getset<_c2py_cls_1>[] = {
    c2py::getsetdef_from_member<&_c2py_cls_1::total, _c2py_cls_1>("total", _c2py_doc_member_2),
-   c2py::getsetdef_from_member<&_c2py_cls_1::per_theta, _c2py_cls_1>("per_theta", _c2py_doc_member_3),
+   c2py::getsetdef_from_member<&_c2py_cls_1::projected, _c2py_cls_1>("projected", _c2py_doc_member_3),
    {"__dict__", (getter)prop_get_dict_1, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
@@ -167,10 +172,10 @@ const std::string c2py::tp_doc<_c2py_cls_1> =
 
 // projected_spectral_function
 static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
-   c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe_theta, const triqs::modest::downfolding_projector &Proj, double mu,
+   c2py::cfun([](const triqs::modest::one_body_elements_on_grid &obe, const triqs::modest::downfolding_projector &Proj, double mu,
                  const triqs::gfs::block_gf<triqs::mesh::refreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_w,
-                 double broadening) { return triqs::modest::projected_spectral_function(obe_theta, Proj, mu, Sigma_w, broadening); },
-              "obe_theta", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
+                 double broadening) { return triqs::modest::projected_spectral_function(obe, Proj, mu, Sigma_w, broadening); },
+              "obe", "Proj", "mu", "Sigma_w", "broadening"_a = 0.01)};
 
 // spectral_function
 static auto const _c2py_fun_1 =
@@ -192,8 +197,8 @@ Compute the atom- and orbital-resolved spectral function (interacting density of
 
 Parameters
 ----------
-obe_theta : {par_0}
-   One-body elements on grid created from one_body_elements_with_theta_projectors.
+obe : {par_0}
+   One-body elements on grid created from one_body_elements_with_partial_projectors.
 Proj : {par_1}
    Downfolding projector defined in the correlated space using to upfold the DMFT self-energies.
 mu : {par_2}
@@ -332,6 +337,13 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_post_processi
   _add_type(_c2py_cls_0, "SpectralFunctionKw");
   _add_type(_c2py_cls_1, "SpectralFunctionW");
 #undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
+  register_h5_type<_c2py_cls_1>(register_class);
 
   return m;
 }

--- a/python/triqs_modest/rho_and_mu.wrap.cxx
+++ b/python/triqs_modest/rho_and_mu.wrap.cxx
@@ -27,6 +27,19 @@ using c2py::operator""_a;
 // density
 static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
    c2py::cfun(
+      [](const triqs::modest::one_body_elements_tb &obe, double mu,
+         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
+         const nda::basic_array<
+            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
+         const triqs::experimental::lattice::bz_int_options &opt) {
+        return triqs::modest::density<triqs::mesh::imfreq>(obe, mu, Sigma_dynamic, Sigma_static, opt);
+      },
+      "obe", "mu", "Sigma_dynamic", "Sigma_static", "opt"),
+   c2py::cfun([](const triqs::modest::one_body_elements_tb &obe, double mu, const triqs::mesh::imfreq &mesh,
+                 const triqs::experimental::lattice::bz_int_options &opt) { return triqs::modest::density<triqs::mesh::imfreq>(obe, mu, mesh, opt); },
+              "obe", "mu", "mesh", "opt"),
+   c2py::cfun(
       [](const triqs::modest::one_body_elements_on_grid &obe, double mu,
          const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
          const nda::basic_array<
@@ -43,20 +56,7 @@ static auto const _c2py_fun_0 = c2py::dispatcher_f_kw_t{
             nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static) {
         return triqs::modest::density<triqs::mesh::dlr_imfreq>(obe, mu, Sigma_dynamic, Sigma_static);
       },
-      "obe", "mu", "Sigma_dynamic", "Sigma_static"),
-   c2py::cfun(
-      [](const triqs::modest::one_body_elements_tb &obe, double mu,
-         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
-         const nda::basic_array<
-            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
-            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
-         const triqs::experimental::lattice::bz_int_options &opt) {
-        return triqs::modest::density<triqs::mesh::imfreq>(obe, mu, Sigma_dynamic, Sigma_static, opt);
-      },
-      "obe", "mu", "Sigma_dynamic", "Sigma_static", "opt"),
-   c2py::cfun([](const triqs::modest::one_body_elements_tb &obe, double mu, const triqs::mesh::imfreq &mesh,
-                 const triqs::experimental::lattice::bz_int_options &opt) { return triqs::modest::density<triqs::mesh::imfreq>(obe, mu, mesh, opt); },
-              "obe", "mu", "mesh", "opt")};
+      "obe", "mu", "Sigma_dynamic", "Sigma_static")};
 
 // density_nk
 static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
@@ -64,61 +64,63 @@ static auto const _c2py_fun_1 = c2py::dispatcher_f_kw_t{
               "obe", "mu", "beta")};
 
 // find_chemical_potential
-static auto const _c2py_fun_2 = c2py::dispatcher_f_kw_t{
-   c2py::cfun([](const double target_density, const triqs::modest::one_body_elements_on_grid &obe, double beta, std::string method, double precision,
-                 bool verbosity) { return triqs::modest::find_chemical_potential(target_density, obe, beta, method, precision, verbosity); },
-              "target_density", "obe", "beta", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
-   c2py::cfun(
-      [](const double target_density, const triqs::modest::one_body_elements_on_grid &obe,
-         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
-         const nda::basic_array<
-            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
-            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
-         std::string method, double precision, bool verbosity) {
-        return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, method, precision,
-                                                                           verbosity);
-      },
-      "target_density", "obe", "Sigma_dynamic", "Sigma_static", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
-   c2py::cfun(
-      [](const double target_density, const triqs::modest::one_body_elements_on_grid &obe,
-         const triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
-         const nda::basic_array<
-            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
-            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
-         std::string method, double precision, bool verbosity) {
-        return triqs::modest::find_chemical_potential<triqs::mesh::dlr_imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, method, precision,
-                                                                               verbosity);
-      },
-      "target_density", "obe", "Sigma_dynamic", "Sigma_static", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
-   c2py::cfun(
-      [](const double target_density, const triqs::modest::one_body_elements_tb &obe,
-         const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
-         const nda::basic_array<
-            nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
-            nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
-         const triqs::experimental::lattice::bz_int_options &opt, std::string method, double precision, bool verbosity) {
-        return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, opt, method, precision,
-                                                                           verbosity);
-      },
-      "target_density", "obe", "Sigma_dynamic", "Sigma_static", "opt", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
-   c2py::cfun(
-      [](const double target_density, const triqs::modest::one_body_elements_tb &obe, const triqs::mesh::imfreq &mesh,
-         const triqs::experimental::lattice::bz_int_options &opt, std::string method, double precision, bool verbosity) {
-        return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, mesh, opt, method, precision, verbosity);
-      },
-      "target_density", "obe", "mesh", "opt", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true)};
+static auto const _c2py_fun_2 =
+   c2py::dispatcher_f_kw_t{
+      c2py::cfun(
+         [](const double target_density, const triqs::modest::one_body_elements_tb &obe,
+            const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
+            const nda::basic_array<
+               nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+               nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
+            const triqs::experimental::lattice::bz_int_options &opt, std::string method, double precision, bool verbosity) {
+           return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, opt, method,
+                                                                              precision, verbosity);
+         },
+         "target_density", "obe", "Sigma_dynamic", "Sigma_static", "opt", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
+      c2py::cfun(
+         [](const double target_density, const triqs::modest::one_body_elements_tb &obe, const triqs::mesh::imfreq &mesh,
+            const triqs::experimental::lattice::bz_int_options &opt, std::string method, double precision, bool verbosity) {
+           return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, mesh, opt, method, precision, verbosity);
+         },
+         "target_density", "obe", "mesh", "opt", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
+      c2py::cfun([](const double target_density, const triqs::modest::one_body_elements_on_grid &obe, double beta, std::string method,
+                    double precision,
+                    bool verbosity) { return triqs::modest::find_chemical_potential(target_density, obe, beta, method, precision, verbosity); },
+                 "target_density", "obe", "beta", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
+      c2py::cfun(
+         [](const double target_density, const triqs::modest::one_body_elements_on_grid &obe,
+            const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
+            const nda::basic_array<
+               nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+               nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
+            std::string method, double precision, bool verbosity) {
+           return triqs::modest::find_chemical_potential<triqs::mesh::imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, method, precision,
+                                                                              verbosity);
+         },
+         "target_density", "obe", "Sigma_dynamic", "Sigma_static", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true),
+      c2py::cfun(
+         [](const double target_density, const triqs::modest::one_body_elements_on_grid &obe,
+            const triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &Sigma_dynamic,
+            const nda::basic_array<
+               nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
+               nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &Sigma_static,
+            std::string method, double precision, bool verbosity) {
+           return triqs::modest::find_chemical_potential<triqs::mesh::dlr_imfreq>(target_density, obe, Sigma_dynamic, Sigma_static, method, precision,
+                                                                                  verbosity);
+         },
+         "target_density", "obe", "Sigma_dynamic", "Sigma_static", "method"_a = "dichotomy", "precision"_a = 1.e-5, "verbosity"_a = true)};
 
 static const auto _c2py_doc_0 = _c2py_fun_0.doc(
    R"DOC(
-[1, 2] Compute the density of the lattice Green's function with a self-energy using Woodbury.
+[1] Compute the density of the lattice Green's function with a self-energy.
 
 ------
 
-[3] Compute the density of the lattice Green's function with a self-energy.
+[2] Compute the density of the lattice Green's function without a self-energy.
 
 ------
 
-[4] Compute the density of the lattice Green's function without a self-energy.
+[3, 4] Compute the density of the lattice Green's function with a self-energy using Woodbury.
 
 ------
 
@@ -142,7 +144,7 @@ Returns
 {ret_0}
    Electron density of the lattice Green's function.
 )DOC",
-   {{c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>(), c2py::python_typename<const triqs::modest::one_body_elements_tb &>()},
+   {{c2py::python_typename<const triqs::modest::one_body_elements_tb &>(), c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
     {c2py::python_typename<double>()},
     {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>(),
      c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
@@ -157,11 +159,11 @@ Compute number of particles :math:`n = \sum f(\beta(\varepsilon(k) - μ))`.
 )DOC");
 static const auto _c2py_doc_2 = _c2py_fun_2.doc(
    R"DOC(
-[1] Find the chemical potenital from the local Green's function given a target density.
+[1, 2, 4, 5] Find the chemical potenital from the local Green's function and self-energy given a target density.
 
 ------
 
-[2, 3, 4, 5] Find the chemical potenital from the local Green's function and self-energy given a target density.
+[3] Find the chemical potenital from the local Green's function given a target density.
 
 ------
 
@@ -171,22 +173,22 @@ target_density : {par_0}
    Total electron density.
 obe : {par_1}
    One-body elements.
-beta : {par_2}
-   Inverse temperature (units 1/eV).
-method : {par_3}
-   Root finding method to use (default = `dichotomy`).
-precision : {par_4}
-   Precision to end search (default = 1e-5).
-verbosity : {par_5}
-   Printing of the root finder's progress (default = true).
-Sigma_dynamic : {par_6}
+Sigma_dynamic : {par_2}
    Dynamic part of the embedded self-energy.
-Sigma_static : {par_7}
+Sigma_static : {par_3}
    Static part of the embedded self-energy.
-opt : {par_8}
+opt : {par_4}
    Container for options related to integration of the BZ.
-mesh : {par_9}
+method : {par_5}
+   Root finding method to use (default = `dichotomy`).
+precision : {par_6}
+   Precision to end search (default = 1e-5).
+verbosity : {par_7}
+   Printing of the root finder's progress (default = true).
+mesh : {par_8}
    Mesh on which local GF will be computed.
+beta : {par_9}
+   Inverse temperature (units 1/eV).
 
 Returns
 -------
@@ -194,18 +196,18 @@ Returns
    Chemical potential corresponding to target density.
 )DOC",
    {{c2py::python_typename<const double>()},
-    {c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>(), c2py::python_typename<const triqs::modest::one_body_elements_tb &>()},
-    {c2py::python_typename<double>()},
-    {c2py::python_typename<std::string>()},
-    {c2py::python_typename<double>()},
-    {c2py::python_typename<bool>()},
+    {c2py::python_typename<const triqs::modest::one_body_elements_tb &>(), c2py::python_typename<const triqs::modest::one_body_elements_on_grid &>()},
     {c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>(),
      c2py::python_typename<const triqs::gfs::block_gf<triqs::mesh::dlr_imfreq, triqs::gfs::matrix_valued, nda::C_layout, 2> &>()},
     {c2py::python_typename<const nda::basic_array<
        nda::basic_array<std::complex<double>, 2, nda::C_layout, 'M', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>>, 2,
        nda::C_layout, 'A', nda::heap_basic<nda::mem::mallocator<nda::mem::AddressSpace::Host>>> &>()},
     {c2py::python_typename<const triqs::experimental::lattice::bz_int_options &>()},
-    {c2py::python_typename<const triqs::mesh::imfreq &>()}},
+    {c2py::python_typename<std::string>()},
+    {c2py::python_typename<double>()},
+    {c2py::python_typename<bool>()},
+    {c2py::python_typename<const triqs::mesh::imfreq &>()},
+    {c2py::python_typename<double>()}},
    {c2py::python_typename<double>()});
 //--------------------- module function table  -----------------------------
 

--- a/python/triqs_modest/utils/checkpoint.py
+++ b/python/triqs_modest/utils/checkpoint.py
@@ -7,9 +7,12 @@ Wraps CheckpointBase (the c2py-exposed C++ class) and adds:
 - Keyword-extras written alongside required iteration data (master only)
 - restart() broadcasts last iteration to all ranks (collective)
 - Full Python iteration, indexing, and len() support
+- summarize() prints a convergence log of mu and orbital-resolved occupations
 """
 
 import os
+import sys
+import numpy as np
 import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 from .file_io import CheckpointBase, IterationData
@@ -20,9 +23,13 @@ __all__ = ["Checkpointer", "IterationData"]
 class Checkpointer:
     """MPI-aware checkpoint manager for DMFT calculations.
 
-    Enforces saving the minimal restart set (mu, Sigma_imp_list, Sigma_hartree_list)
-    per iteration and optionally stores additional quantities (Green's functions,
-    density matrices, etc.) in the same HDF5 group via keyword arguments.
+    Stores per iteration the restart-required self-energies (``mu``,
+    ``Sigma_imp_list``, ``Sigma_hartree_list``) along with optional inputs
+    (``Gloc_list``, ``Delta_list``) and outputs (``Gimp_list``,
+    ``Sigma_dc_list``) of the impurity solve. The optional fields default
+    to empty lists — simple DMFT runs can ignore them; CSC and ML workflows
+    fill them in. Anything else can still be passed through ``**extras``
+    and written to the same HDF5 group via ``HDFArchive``.
 
     All methods are safe to call on all MPI ranks — no ``is_master_node()`` guards
     required in user code. Only the master process performs HDF5 file I/O.
@@ -41,23 +48,28 @@ class Checkpointer:
 
     .. code-block:: python
 
-        chkpt    = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding" : E})
-        last     = chkpt.restart()          # collective — data on all ranks
+        chkpt = Checkpointer("my_calc", initial_data={"obe": obe, "Embedding": E})
+        last  = chkpt.restart()              # collective — data on all ranks
         if last is not None:
             Sigma_dyn    = last.Sigma_imp_list[0]
             Sigma_static = last.Sigma_hartree_list[0]
+            Sigma_dc     = last.Sigma_dc_list[0] if last.Sigma_dc_list else None
         else:
             Sigma_dyn, Sigma_static = make_zero_self_energies(mesh)
+            Sigma_dc = None
 
         it_shift = len(chkpt)
 
         for n in range(it_shift, n_loops):
             ...
-            chkpt.append(
-                IterationData(mu=mu, Sigma_imp_list=[Sigma_dyn],
-                              Sigma_hartree_list=[Sigma_static]),
-                Delta_iw=Delta, Gimp_iw=Gimp, dm=dm,
-            )
+            chkpt.append(IterationData(
+                mu=mu,
+                Sigma_imp_list=[Sigma_dyn], Sigma_hartree_list=[Sigma_static],
+                Gimp_list=[Gimp], Sigma_dc_list=[Sigma_dc] if Sigma_dc is not None else [],
+                Gloc_list=[Gloc], Delta_list=[Delta],
+            ))
+
+        chkpt.summarize()                    # print a convergence log
     """
 
     def __init__(self, dirname, initial_data=None) -> None:
@@ -97,8 +109,14 @@ class Checkpointer:
         """Return last iteration data on all MPI ranks, or None if empty.
 
         Collective operation — all ranks must call this together. Master reads
-        from disk; components (mu, Sigma_imp_list, Sigma_hartree_list) are
-        broadcast individually to all ranks.
+        from disk; the returned ``IterationData`` is broadcast to all ranks.
+
+        Carries the restart-relevant fields: ``mu``, ``Sigma_imp_list``,
+        ``Sigma_hartree_list``, and ``Sigma_dc_list``. The DC list is ``[]``
+        for non-CSC runs and populated for CSC; callers can detect with
+        ``if it.Sigma_dc_list:``. Diagnostic fields (``Gimp_list``,
+        ``Gloc_list``, ``Delta_list``) are not in the restart payload — read
+        them via ``chkpt[i]`` on master or via ``summarize()``.
 
         Returns
         -------
@@ -112,12 +130,82 @@ class Checkpointer:
 
         iter_data = None
         if mpi.is_master_node():
-            mu             = self._cpp[-1].mu                
-            Sigma_imp_list = self._cpp[-1].Sigma_imp_list    
-            Sigma_H_list   = self._cpp[-1].Sigma_hartree_list
-            iter_data = IterationData(mu=mu, Sigma_imp_list=Sigma_imp_list, Sigma_hartree_list=Sigma_H_list)
+            last = self._cpp[-1]
+            iter_data = IterationData(
+                mu=last.mu,
+                Sigma_imp_list=last.Sigma_imp_list,
+                Sigma_hartree_list=last.Sigma_hartree_list,
+                Sigma_dc_list=last.Sigma_dc_list,
+            )
         iter_data = mpi.bcast(iter_data)
         return iter_data
+
+
+    def summarize(self, file=None) -> None:
+        """Print a per-iteration convergence log (master only).
+
+        Columns are ``iter``, ``mu``, and the orbital-resolved diagonal
+        occupations from ``Gimp_list`` and ``Gloc_list``. Column groups are
+        skipped if no iteration in the checkpoint has the corresponding list
+        populated. Iterations whose individual lists are empty show ``--``
+        placeholders.
+
+        Parameters
+        ----------
+        file : file-like, optional
+            Destination stream; defaults to ``sys.stdout``.
+        """
+        if not mpi.is_master_node(): return
+        if file is None: file = sys.stdout
+
+        n_iter = len(self._cpp)
+        if n_iter == 0:
+            print("Checkpointer: no iterations stored.", file=file)
+            return
+
+        iters = [self._cpp[n] for n in range(n_iter)]
+
+        def orbital_layout(blocklist):
+            """Return [(imp_idx, block_name, orb_idx), ...] from the first non-empty list, or []."""
+            for it in iters:
+                lst = blocklist(it)
+                if lst:
+                    layout = []
+                    for i, bgf in enumerate(lst):
+                        for bn, g in bgf:
+                            for a in range(g.target_shape[0]):
+                                layout.append((i, bn, a))
+                    return layout
+            return []
+
+        imp_layout = orbital_layout(lambda it: it.Gimp_list)
+        loc_layout = orbital_layout(lambda it: it.Gloc_list)
+
+        headers = ["iter", "mu"]
+        headers += [f"n_imp{i}_{bn}_{a}_imp" for (i, bn, a) in imp_layout]
+        headers += [f"n_imp{i}_{bn}_{a}_loc" for (i, bn, a) in loc_layout]
+        widths = [max(len(h), 12) for h in headers]
+
+        def fmt_row(cells):
+            return "  ".join(f"{c:>{w}}" for c, w in zip(cells, widths))
+
+        print(fmt_row(headers), file=file)
+        print("  ".join("-" * w for w in widths), file=file)
+
+        def diag_occupations(blocklist, layout):
+            if not blocklist:
+                return ["--"] * len(layout)
+            diags = {}
+            for i, bgf in enumerate(blocklist):
+                for bn, g in bgf:
+                    diags[(i, bn)] = np.diag(g.density()).real
+            return [f"{diags[(i, bn)][a]:.6f}" for (i, bn, a) in layout]
+
+        for n, it in enumerate(iters):
+            row = [str(n), f"{it.mu:.6f}"]
+            row += diag_occupations(it.Gimp_list, imp_layout)
+            row += diag_occupations(it.Gloc_list, loc_layout)
+            print(fmt_row(row), file=file)
 
 
     @property

--- a/python/triqs_modest/utils/file_io.wrap.cxx
+++ b/python/triqs_modest/utils/file_io.wrap.cxx
@@ -15,6 +15,7 @@
 #define C2PY_VERSION_MINOR 1
 
 #include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
 
 using c2py::operator""_a;
 
@@ -44,14 +45,18 @@ static int synth_constructor_0(PyObject *self, PyObject *args, PyObject *kwargs)
   de("mu", self_c.mu, false);
   de("Sigma_imp_list", self_c.Sigma_imp_list, false);
   de("Sigma_hartree_list", self_c.Sigma_hartree_list, false);
+  de("Gimp_list", self_c.Gimp_list, true);
+  de("Sigma_dc_list", self_c.Sigma_dc_list, true);
+  de("Gloc_list", self_c.Gloc_list, true);
+  de("Delta_list", self_c.Delta_list, true);
   return de.check();
 }
 
 template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = synth_constructor_0;
 
 template <>
-const std::string c2py::tp_ctor_doc<_c2py_cls_0> =
-   c2py::replace_tags(R"DOC(Synthesized constructor with the following keyword arguments:
+const std::string c2py::tp_ctor_doc<_c2py_cls_0> = c2py::replace_tags(
+   R"DOC(Synthesized constructor with the following keyword arguments:
 
 Parameters
 ----------
@@ -61,27 +66,47 @@ Sigma_imp_list : {par_1}
 
 Sigma_hartree_list : {par_2}
 
+Gimp_list : {par_3}, default={}
+
+Sigma_dc_list : {par_4}, default={}
+
+Gloc_list : {par_5}, default={}
+
+Delta_list : {par_6}, default={}
+
 )DOC",
-                      "par",
-                      {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
-                       c2py::python_typename<std::vector<triqs::modest::block_mat_t>>()});
+   "par",
+   {c2py::python_typename<double>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_mat_t>>(), c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>(),
+    c2py::python_typename<std::vector<triqs::modest::block_gf_imfreq_t>>()});
 
 // ----- Method table ----
 template <>
 PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
-
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
    {nullptr, nullptr, 0, nullptr} // Sentinel
 };
 
 constexpr auto _c2py_doc_member_0 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_1 = R"DOC()DOC";
 constexpr auto _c2py_doc_member_2 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_3 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_4 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_5 = R"DOC()DOC";
+constexpr auto _c2py_doc_member_6 = R"DOC()DOC";
 static PyObject *prop_get_dict_0(PyObject *self, void *) {
   auto &self_c = *(((c2py::wrap<_c2py_cls_0> *)self)->_c);
   c2py::pydict dic;
   dic["mu"]                 = self_c.mu;
   dic["Sigma_imp_list"]     = self_c.Sigma_imp_list;
   dic["Sigma_hartree_list"] = self_c.Sigma_hartree_list;
+  dic["Gimp_list"]          = self_c.Gimp_list;
+  dic["Sigma_dc_list"]      = self_c.Sigma_dc_list;
+  dic["Gloc_list"]          = self_c.Gloc_list;
+  dic["Delta_list"]         = self_c.Delta_list;
   return dic.new_ref();
 }
 
@@ -92,12 +117,21 @@ constinit PyGetSetDef c2py::tp_getset<_c2py_cls_0>[] = {
    c2py::getsetdef_from_member<&_c2py_cls_0::mu, _c2py_cls_0>("mu", _c2py_doc_member_0),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_imp_list, _c2py_cls_0>("Sigma_imp_list", _c2py_doc_member_1),
    c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_hartree_list, _c2py_cls_0>("Sigma_hartree_list", _c2py_doc_member_2),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gimp_list, _c2py_cls_0>("Gimp_list", _c2py_doc_member_3),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Sigma_dc_list, _c2py_cls_0>("Sigma_dc_list", _c2py_doc_member_4),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Gloc_list, _c2py_cls_0>("Gloc_list", _c2py_doc_member_5),
+   c2py::getsetdef_from_member<&_c2py_cls_0::Delta_list, _c2py_cls_0>("Delta_list", _c2py_doc_member_6),
    {"__dict__", (getter)prop_get_dict_0, nullptr, "", nullptr},
    {nullptr, nullptr, nullptr, nullptr, nullptr}};
 
 template <>
-const std::string c2py::tp_doc<_c2py_cls_0> =
-   R"DOC(Minimal iteration data required to restart a DMFT loop.)DOC" + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
+const std::string c2py::tp_doc<_c2py_cls_0> = R"DOC(Per-iteration DMFT data: restart-required self-energies plus optional inputs/outputs.
+
+The fields split semantically into inputs to the impurity solver (Gloc, Delta) and outputs
+from it (Gimp, Sigma_imp, Sigma_hartree, Sigma_dc). The HDF5 layout mirrors that split
+(`inputs/` and `outputs/` subgroups); the API is flat. All optional fields default to
+empty vectors so callers only fill what they have.)DOC"
+   + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
 // --------- class _c2py_cls_1 -----------
 using _c2py_cls_1                                            = triqs::modest::checkpoint<triqs::modest::iteration_data>;
 template <> constexpr bool c2py::is_wrapped<_c2py_cls_1>     = true;
@@ -197,6 +231,12 @@ extern "C" __attribute__((visibility("default"))) PyObject *PyInit_file_io() {
   _add_type(_c2py_cls_0, "IterationData");
   _add_type(_c2py_cls_1, "CheckpointBase");
 #undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
 
   return m;
 }

--- a/test/c++/load_data_test.cpp
+++ b/test/c++/load_data_test.cpp
@@ -52,7 +52,7 @@ TEST(load_data_tests, obe_high_symm_path) {
 TEST(load_data_tests, obe_parproj) {
   auto [_, obe] = one_body_elements_from_dft_converter("ref_data/SrVO3-cubic-t2g.ref.h5");
   std::cout << obe << std::endl;
-  auto obe_dos = one_body_elements_with_theta_projectors("ref_data/SrVO3-cubic-t2g.ref.h5", obe);
+  auto obe_dos = one_body_elements_with_partial_projectors("ref_data/SrVO3-cubic-t2g.ref.h5", obe);
   std::cout << obe_dos << std::endl;
 }
 

--- a/test/c++/mpi_test.cpp
+++ b/test/c++/mpi_test.cpp
@@ -33,13 +33,13 @@ TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithHighSymmPath) {
   EXPECT_EQ(obe2, ref_obe_bands);
 }
 
-TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithThetaProjectors) {
+TEST_F(MpiTest, BroadcastOneBodyElementsOnGridWithPartialProjectors) {
   std::string const filename = "ref_data/SrVO3-cubic-t2g.ref.h5";
   auto [target_density, obe] = one_body_elements_from_dft_converter(filename);
   // implicity reads on rank 0 and broadcasts
-  auto obe2 = one_body_elements_with_theta_projectors(filename, obe);
+  auto obe2 = one_body_elements_with_partial_projectors(filename, obe);
   // read on all ranks the data
-  auto ref_obe = read_theta_projectors_for_obe(filename, obe);
+  auto ref_obe = read_partial_projectors_for_obe(filename, obe);
   EXPECT_EQ(obe2, ref_obe);
 }
 

--- a/test/c++/obe_tb_test.cpp
+++ b/test/c++/obe_tb_test.cpp
@@ -52,14 +52,14 @@ TEST(obe_tb, lco_wannier90) { // NOLINT
 
   // run gloc, forcing gloc to use PTR on the same grid as the DFT calculation was done
   bz_int_options opt = {.k_grid = {7, 7, 7}, .k_grid_max = {7, 7, 7}, .run_adaptive = false};
-  auto gloc_tb                       = gloc(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
+  auto gloc_tb       = gloc(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
 
   // Check equivalence
   for (auto iw : iw_mesh) { EXPECT_COMPLEX_NEAR(gloc_tb(0, 0)[iw](0, 0), gloc_dft(0, 0)[iw](0, 0), 1e-5); }
 
   // density calculation for one spin channel, using the function which takes self energy and also the function assuming zero self energy
-  double n = density(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
-  double n_zero_sigma = density(obe_tb, mu_dft, iw_mesh, opt); 
+  double n            = density(obe_tb, mu_dft, Sigma_block2, Sigma_static, opt);
+  double n_zero_sigma = density(obe_tb, mu_dft, iw_mesh, opt);
   EXPECT_NEAR(n, 1.0, 1e-4);
   EXPECT_NEAR(n_zero_sigma, 1.0, 1e-4);
 
@@ -100,10 +100,10 @@ TEST(obe_tb, svo_t2g_wannier90_multiorbtial) { // NOLINT
 
   // run gloc, forcing gloc to use PTR on the same grid as the DFT calculation was done
   bz_int_options opt = {.k_grid = {5, 5, 5}, .k_grid_max = {5, 5, 5}, .run_adaptive = false};
-  auto gloc_tb                       = gloc(iw_mesh, obe_tb, mu_dft, opt);
+  auto gloc_tb       = gloc(iw_mesh, obe_tb, mu_dft, opt);
 
-  // NOTE: The first frequency point here does not agree exactly, likely due to a small 
-  // difference in the Wannier H vs. the DFT data. 
+  // NOTE: The first frequency point here does not agree exactly, likely due to a small
+  // difference in the Wannier H vs. the DFT data.
   // This may also be due to the fact that DFT mesh was on [-0.5,0.5), and the PTR integration is 0,1
   for (auto iw : iw_mesh) { //
     if (std::abs(dcomplex(iw.value())) < 1.7) {


### PR DESCRIPTION
**Draft**: this PR depends on PR#16, so we can review once that one lands on top of unstable.

**Incremental diff (this PR only):**
[`pr/woodbury-kernel...pr/postprocess-tb`](https://github.com/harrisonlabollita/modest/compare/pr/woodbury-kernel...pr/postprocess-tb)

---

## Summary

Two related changes to the post-processing layer: simplify the
`projected_spectral_function` signature (and drop the redundant
`spectral_function`), then extend spectral-function support to tight-binding OBE,
which previously had none.

## 1. `projected_spectral_function` (`e2f9724`)

 **Python API change.** Needs a `ChangeLog.md` entry.

```python
# before
projected_spectral_function(obe, Proj, mu, Sigma_w, broadening)
# after
projected_spectral_function(obe, mu, Sigma_w, broadening)
```

In the common case `obe.P` *is* the projector that upfolds the self-energy, so
requiring the caller to pass it a second time was noise. The two-projector form
survives as an overload for the genuine use case — a partial projector that
projects \(G_{\nu\nu'}(\omega)\) into the W space rather than the C space.

**Removed:** `spectral_function(obe, mu, Sigma_w, broadening) -> nda::array<double, 4>`.

The real-frequency spectral-function paths are also ported onto the Woodbury
kernel from PR #16 .

## 2. Tight-binding post-processing (`b08de1e`)

New entry points for `one_body_elements_tb`:

- `projected_spectral_function(obe, mu, Sigma_w, opt, broadening)`
- `spectral_function_on_high_symmetry_path(obe, k_list, mu, Sigma_w, broadening)`

The API choice is a suggestion. Let's discuss alternatives as part of the review.

The TB Hamiltonian is already in the Wannier basis, so \(\Sigma\) is embedded by
**index-slicing rather than projector multiplication**.